### PR TITLE
[BUG] 라우터 경로 이동 시 네비게이션 바 로고 애니메이션 버그를 수정합니다.

### DIFF
--- a/src/common/ScrollToTop.ts
+++ b/src/common/ScrollToTop.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/src/components/header/NavigationBarLogo.tsx
+++ b/src/components/header/NavigationBarLogo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState, useRef } from 'react';
 
 import { Link, useLocation } from 'react-router-dom';
 import { motion, useAnimation, useScroll } from 'framer-motion';
@@ -7,29 +7,28 @@ import logo from '@/assets/logo/logo_gray_3d.svg';
 import { ROUTER_PATH } from '@/constants/constant';
 
 const NavigationBarLogo = () => {
+  const [isScrolled, setIsScrolled] = useState(false);
   const location = useLocation();
-  const [yPos, setYPos] = useState(
-    window.innerHeight / 2 - window.innerHeight / 8,
-  );
-  const [isScrolled, setIsScrolled] = useState(true);
+  const prevPathRef = useRef(location.pathname); // 이전 경로 저장 → 홈페이지로 진입할 때마다 로고 크기를 커진 상태로 설정하기 위함
   const controls = useAnimation();
   const { scrollYProgress } = useScroll();
+
   const isHomePage = location.pathname === '/';
+  const yPos = window.innerHeight / 2 - window.innerHeight / 8;
 
   useLayoutEffect(() => {
     if (!isHomePage) {
       controls.set({ scale: 1, y: 0 });
+      setIsScrolled(true);
       return;
     }
 
-    if (window.scrollY > 0) {
-      setIsScrolled(true);
-      controls.set({ scale: 1, y: 0 });
-    } else {
-      setIsScrolled(false);
-      controls.set({ scale: 4, y: yPos });
-    }
-  }, [controls, yPos, isHomePage]);
+    // 홈페이지로 진입할 때마다 로고를 커진 상태로 설정
+    setIsScrolled(false);
+    controls.set({ scale: 4, y: yPos });
+
+    prevPathRef.current = location.pathname;
+  }, [controls, yPos, isHomePage, location.pathname]);
 
   useEffect(() => {
     if (!isHomePage) return;
@@ -37,25 +36,29 @@ const NavigationBarLogo = () => {
     const handleScroll = () => {
       const progress = scrollYProgress.get();
 
-      if (progress > 0 && progress <= 0.07) {
-        setYPos(window.innerHeight / 2 - window.innerHeight / 8);
+      if (progress === 0) {
+        setIsScrolled(false);
         controls.start({
           scale: 4,
           y: yPos,
-          transition: {
-            ease: 'easeIn',
-          },
+          transition: { ease: 'easeIn' },
+        });
+      } else if (progress > 0 && progress <= 0.07) {
+        controls.start({
+          scale: 4 - (3 * progress) / 0.07, // 스크롤을 내릴수록 로고 크기가 줄어듦
+          y: yPos * (1 - progress / 0.07), // 스크롤을 내릴수록 로고가 위로 올라감
+          transition: { ease: 'easeIn' },
         });
       } else if (progress > 0.07) {
+        setIsScrolled(true);
         controls.start({
           scale: 1,
           y: 0,
-          transition: {
-            ease: 'easeOut',
-          },
+          transition: { ease: 'easeOut' },
         });
       }
     };
+
     scrollYProgress.on('change', handleScroll);
     return () => scrollYProgress.clearListeners();
   }, [scrollYProgress, controls, yPos, isHomePage]);

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -10,6 +10,7 @@ import PlayerPage from '@/pages/PlayerPage';
 import NewsPage from '@/pages/NewsPage';
 import LoginPage from '@/pages/LoginPage';
 import SingupPage from '@/pages/SignupPage';
+import ScrollToTop from '@/common/ScrollToTop';
 import { ROUTER_PATH } from '@/constants/constant';
 
 const Router = () => {
@@ -26,7 +27,12 @@ const Router = () => {
   } = ROUTER_PATH;
   const router = createBrowserRouter([
     {
-      element: <Layout />,
+      element: (
+        <>
+          <ScrollToTop />
+          <Layout />
+        </>
+      ),
       children: [
         { path: HOME, element: <HomePage /> },
         { path: INTRODUCE, element: <IntroductionPage /> },


### PR DESCRIPTION
## ⚾️ Related Issues

- close #30 

## 📝 Task Details

- `ScrollToTop` 컴포넌트를 제작합니다.
- `NavigationBarLogo` 컴포넌트에 애니메이션 문제를 수정합니다.

## 📂 References

https://github.com/user-attachments/assets/f42d5158-9be4-4a7a-878b-a705d5475b96

## 💕 Review Requirements

- 라우터 경로를 변경하면 화면 맨 위부터 보여지게 됩니다.
- 이제 이전 페이지에서 스크롤 된 채로 메인페이지로 이동해도 메인로고가 크게 나타나는 것을 확인할 수 있습니다.
- 처음에 수정했을 때는 로고 애니메이션이 약간 늦게 반응하거나 이상하게 반응했었는데 `progress`에 따라서 `scale`되는 것을 함께 미세하게 조정하여 원래의 애니메이션처럼 동작하도록 하였습니다.