### PR TITLE
[FEAT] 정규 리그 페이지의 박스스코어 페이지를 퍼블리싱합니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@tanstack/react-query": "^5.53.3",
+        "@tanstack/react-table": "^8.20.5",
         "axios": "^1.7.7",
         "clsx": "^2.1.1",
         "framer-motion": "^11.3.31",
@@ -1678,6 +1679,37 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.20.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.20.5.tgz",
+      "integrity": "sha512-WEHopKw3znbUZ61s9i0+i9g8drmDo6asTWbrQh8Us63DAk/M0FkmIqERew6P71HI75ksZ2Pxyuf4vvKh9rAkiA==",
+      "dependencies": {
+        "@tanstack/table-core": "8.20.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.20.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.20.5.tgz",
+      "integrity": "sha512-P9dF7XbibHph2PFRz8gfBKEXEY/HJPOhym8CHmjF8y3q5mWpKx9xtZapXQUWCgkqvsK0R46Azuz+VaxD4Xl+Tg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/conventional-commits-parser": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.53.3",
+    "@tanstack/react-table": "^8.20.5",
     "axios": "^1.7.7",
     "clsx": "^2.1.1",
     "framer-motion": "^11.3.31",

--- a/src/api/GetBoxScore.ts
+++ b/src/api/GetBoxScore.ts
@@ -1,0 +1,62 @@
+import { useAxios } from '@/hooks/useAxios';
+
+import {
+  BoxScoreGameScheduleType,
+  BoxScoreScoreBoardType,
+} from '@/types/BoxScoreType';
+
+interface BoxScoreData {
+  schedule: {
+    current: BoxScoreGameScheduleType;
+    next: BoxScoreGameScheduleType;
+    prev: BoxScoreGameScheduleType;
+  };
+  scoreboard: BoxScoreScoreBoardType[];
+}
+
+interface GetBoxScoreResponse {
+  data: BoxScoreData;
+}
+
+const scheduleInitialState: BoxScoreGameScheduleType = {
+  broadcast: '',
+  cancelFlag: '',
+  crowdCn: 0,
+  endFlag: '',
+  gameDate: 0,
+  gday: 0,
+  gmkey: '',
+  gmonth: 0,
+  gtime: '',
+  gyear: '',
+  home: '',
+  homeKey: '',
+  hscore: 0,
+  stadium: '',
+  stadiumKey: '',
+  visit: '',
+  visitKey: '',
+  vscore: 0,
+};
+
+const GetBoxScore = (gameDate: number, gmkey: string) => {
+  const { data, isLoading, isError, error } = useAxios<GetBoxScoreResponse>({
+    method: 'GET',
+    url: `/game/boxscore?gameDate=${gameDate}&gmkey=${gmkey}`,
+    initialData: {
+      data: {
+        schedule: {
+          current: scheduleInitialState,
+          next: scheduleInitialState,
+          prev: scheduleInitialState,
+        },
+        scoreboard: [],
+      },
+    },
+    shouldFetchOnMount: true,
+  });
+
+  return { data, isLoading, isError, error };
+};
+
+export { GetBoxScore };

--- a/src/api/GetBoxScore.ts
+++ b/src/api/GetBoxScore.ts
@@ -39,11 +39,13 @@ const scheduleInitialState: BoxScoreGameScheduleType = {
   gyear: '',
   home: '',
   homeKey: '',
+  homeLogo: '',
   hscore: 0,
   stadium: '',
   stadiumKey: '',
   visit: '',
   visitKey: '',
+  visitLogo: '',
   vscore: 0,
 };
 

--- a/src/api/GetBoxScore.ts
+++ b/src/api/GetBoxScore.ts
@@ -3,9 +3,17 @@ import { useAxios } from '@/hooks/useAxios';
 import {
   BoxScoreGameScheduleType,
   BoxScoreScoreBoardType,
+  EtcGamesType,
+  BattersType,
+  PitchersType,
 } from '@/types/BoxScoreType';
 
 interface BoxScoreData {
+  etcgames: EtcGamesType[];
+  hbatters: BattersType[];
+  vbatters: BattersType[];
+  hpitchers: PitchersType[];
+  vpitchers: PitchersType[];
   schedule: {
     current: BoxScoreGameScheduleType;
     next: BoxScoreGameScheduleType;
@@ -45,6 +53,11 @@ const GetBoxScore = (gameDate: number, gmkey: string) => {
     url: `/game/boxscore?gameDate=${gameDate}&gmkey=${gmkey}`,
     initialData: {
       data: {
+        etcgames: [],
+        hbatters: [],
+        vbatters: [],
+        hpitchers: [],
+        vpitchers: [],
         schedule: {
           current: scheduleInitialState,
           next: scheduleInitialState,

--- a/src/components/game/boxscore/BatterRecordTable.tsx
+++ b/src/components/game/boxscore/BatterRecordTable.tsx
@@ -1,12 +1,7 @@
-import {
-  createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+import { createColumnHelper, ColumnDef } from '@tanstack/react-table';
 
 import { BattersType } from '@/types/BoxScoreType';
-import { cn } from '@/utils/cn';
+import { DataTable } from '@/ui/table/DataTable';
 
 type BatterRecordTableProps = {
   data: BattersType[];
@@ -60,59 +55,15 @@ const columns = [
       header: () => '타율',
     },
   ),
-];
+] as ColumnDef<BattersType>[];
 
 const BatterRecordTable = ({ data }: BatterRecordTableProps) => {
-  const table = useReactTable({
-    data,
-    columns,
-    getCoreRowModel: getCoreRowModel(),
-  });
-
   return (
-    <div className="overflow-hidden rounded-md bg-kt-gray-1">
-      <div className="overflow-x-auto">
-        <table className="min-w-full">
-          <thead>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <tr
-                key={headerGroup.id}
-                className="bg-kt-red-2 text-base text-white"
-              >
-                {headerGroup.headers.map((header) => (
-                  <th key={header.id} className="px-3 py-3 text-center">
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </th>
-                ))}
-              </tr>
-            ))}
-          </thead>
-          <tbody className="text-sm font-light text-white">
-            {table.getRowModel().rows.map((row, rowIndex) => (
-              <tr key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <td
-                    key={cell.id}
-                    className={cn(
-                      'whitespace-nowrap border-b border-gray-600 px-3 py-3 text-center',
-                      rowIndex === table.getRowModel().rows.length - 1 &&
-                        'border-b-0',
-                    )}
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+    <DataTable
+      data={data}
+      columns={columns}
+      bodyCellClassName="border-b border-gray-600 text-center"
+    />
   );
 };
 

--- a/src/components/game/boxscore/BatterRecordTable.tsx
+++ b/src/components/game/boxscore/BatterRecordTable.tsx
@@ -1,0 +1,119 @@
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+
+import { BattersType } from '@/types/BoxScoreType';
+import { cn } from '@/utils/cn';
+
+type BatterRecordTableProps = {
+  data: BattersType[];
+};
+
+const columnHelper = createColumnHelper<BattersType>();
+
+const columns = [
+  columnHelper.accessor('oneturn', {
+    cell: (info) => info.getValue(),
+    header: () => '타순',
+  }),
+  columnHelper.accessor('position', {
+    cell: (info) => info.getValue(),
+    header: () => '포지션',
+  }),
+  columnHelper.accessor('name', {
+    cell: (info) => info.getValue(),
+    header: () => '선수명',
+  }),
+  ...Array.from({ length: 9 }, (_, i) =>
+    columnHelper.accessor(`inn${i + 1}` as keyof BattersType, {
+      cell: (info) => info.getValue(),
+      header: () => `${i + 1}회`,
+    }),
+  ),
+  columnHelper.accessor('ab', {
+    cell: (info) => info.getValue(),
+    header: () => '타수',
+  }),
+  columnHelper.accessor('run', {
+    cell: (info) => info.getValue(),
+    header: () => '득점',
+  }),
+  columnHelper.accessor('hit', {
+    cell: (info) => info.getValue(),
+    header: () => '안타',
+  }),
+  columnHelper.accessor('rbi', {
+    cell: (info) => info.getValue(),
+    header: () => '타점',
+  }),
+  columnHelper.accessor(
+    (row) => {
+      const battingAvg = row.accmHit / row.accmAb;
+      return isNaN(battingAvg) ? '-' : battingAvg.toFixed(3);
+    },
+    {
+      id: 'battingAvg',
+      cell: (info) => info.getValue(),
+      header: () => '타율',
+    },
+  ),
+];
+
+const BatterRecordTable = ({ data }: BatterRecordTableProps) => {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <div className="overflow-hidden rounded-md bg-kt-gray-1">
+      <div className="overflow-x-auto">
+        <table className="min-w-full">
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr
+                key={headerGroup.id}
+                className="bg-kt-red-2 text-base text-white"
+              >
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} className="px-3 py-3 text-center">
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody className="text-sm font-light text-white">
+            {table.getRowModel().rows.map((row, rowIndex) => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <td
+                    key={cell.id}
+                    className={cn(
+                      'whitespace-nowrap border-b border-gray-600 px-3 py-3 text-center',
+                      rowIndex === table.getRowModel().rows.length - 1 &&
+                        'border-b-0',
+                    )}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default BatterRecordTable;

--- a/src/components/game/boxscore/BoxScoreItem.tsx
+++ b/src/components/game/boxscore/BoxScoreItem.tsx
@@ -1,0 +1,134 @@
+import { BsArrowLeftCircle, BsArrowRightCircle } from 'react-icons/bs';
+
+import ScoreTable from '@/components/game/boxscore/ScoreTable';
+import {
+  BoxScoreGameScheduleType,
+  BoxScoreScoreBoardType,
+} from '@/types/BoxScoreType';
+import { KtWizMonthSchedule } from '@/types/ScheduleType';
+import { cn } from '@/utils/cn';
+
+type BoxScoreItemProps = {
+  game: BoxScoreGameScheduleType;
+  logo: KtWizMonthSchedule[];
+  scoreBoard: BoxScoreScoreBoardType[];
+  onNextGame: () => void;
+  onPrevGame: () => void;
+  hasNextGame: boolean;
+  hasPrevGame: boolean;
+};
+
+const BoxScoreItem = ({
+  game,
+  logo,
+  scoreBoard,
+  onNextGame,
+  onPrevGame,
+  hasNextGame,
+  hasPrevGame,
+}: BoxScoreItemProps) => {
+  const getTeamLogo = (teamKey: string) => {
+    const teamSchedule = logo.find(
+      (item) =>
+        item.gmkey === game.gmkey &&
+        (item.homeKey === teamKey || item.visitKey === teamKey),
+    );
+    return teamKey === game.homeKey
+      ? teamSchedule?.homeLogo
+      : teamSchedule?.visitLogo;
+  };
+
+  const visitLogo = getTeamLogo(game.visitKey);
+  const homeLogo = getTeamLogo(game.homeKey);
+
+  return (
+    <section className="relative mb-6 rounded-lg bg-kt-black-4 p-12">
+      <header className="flex flex-col">
+        <div className="mb-4 flex items-center justify-between">
+          {/* absolute를 사용하지 않기 위해 빈 공간 추가 */}
+          <div className="w-1/6"></div>
+
+          <div className="flex w-4/6 items-center justify-center gap-8">
+            <button
+              aria-label="이전 날짜"
+              className={cn(
+                'text-white',
+                !hasPrevGame
+                  ? 'cursor-not-allowed text-gray-500'
+                  : 'transition-colors duration-200 hover:text-rose-400',
+              )}
+              onClick={onPrevGame}
+              disabled={!hasPrevGame}
+            >
+              <BsArrowLeftCircle size={30} />
+            </button>
+            <span className="text-3xl font-semibold">
+              {game.gyear}년 {game.gmonth}월 {game.gday}일
+            </span>
+            <button
+              aria-label="다음 날짜"
+              className={cn(
+                'text-white',
+                !hasNextGame
+                  ? 'cursor-not-allowed text-gray-500'
+                  : 'transition-colors duration-200 hover:text-rose-400',
+              )}
+              onClick={onNextGame}
+              disabled={!hasNextGame}
+            >
+              <BsArrowRightCircle size={30} />
+            </button>
+          </div>
+
+          <div className="flex w-1/6 justify-end">
+            <div className="rounded-md bg-gray-700 px-4 py-2 text-white">
+              {game.endFlag === '1' ? '종료된 경기' : '예정 경기'}
+            </div>
+          </div>
+        </div>
+
+        <div className="text-center text-sm">
+          {game.gtime} {game.stadium} | 관중: {game.crowdCn?.toLocaleString()}명
+        </div>
+      </header>
+
+      <main className="grid grid-cols-3 gap-2">
+        <article className="flex flex-col items-center justify-center gap-2">
+          <img
+            src={visitLogo}
+            alt={game.visit}
+            className="h-36 w-36 object-contain"
+          />
+          <p className="text-2xl font-extrabold text-white">{game.vscore}</p>
+          <p className="text-lg font-semibold text-white">
+            {game.visit} (원정)
+          </p>
+        </article>
+
+        <div className="flex items-center justify-center">
+          <p className="text-4xl font-bold text-white">VS</p>
+        </div>
+
+        <section className="flex flex-col items-center justify-center gap-2">
+          <img
+            src={homeLogo}
+            alt={game.home}
+            className="h-36 w-36 object-contain"
+          />
+          <span className="text-2xl font-extrabold text-white">
+            {game.hscore}
+          </span>
+          <span className="text-lg font-semibold text-white">
+            {game.home} (홈)
+          </span>
+        </section>
+
+        <footer className="col-span-3 mt-4">
+          <ScoreTable scoreBoard={scoreBoard} />
+        </footer>
+      </main>
+    </section>
+  );
+};
+
+export default BoxScoreItem;

--- a/src/components/game/boxscore/BoxScoreItem.tsx
+++ b/src/components/game/boxscore/BoxScoreItem.tsx
@@ -5,12 +5,10 @@ import {
   BoxScoreGameScheduleType,
   BoxScoreScoreBoardType,
 } from '@/types/BoxScoreType';
-import { KtWizMonthSchedule } from '@/types/ScheduleType';
 import { cn } from '@/utils/cn';
 
 type BoxScoreItemProps = {
   game: BoxScoreGameScheduleType;
-  logo: KtWizMonthSchedule[];
   scoreBoard: BoxScoreScoreBoardType[];
   onNextGame: () => void;
   onPrevGame: () => void;
@@ -20,27 +18,12 @@ type BoxScoreItemProps = {
 
 const BoxScoreItem = ({
   game,
-  logo,
   scoreBoard,
   onNextGame,
   onPrevGame,
   hasNextGame,
   hasPrevGame,
 }: BoxScoreItemProps) => {
-  const getTeamLogo = (teamKey: string) => {
-    const teamSchedule = logo.find(
-      (item) =>
-        item.gmkey === game.gmkey &&
-        (item.homeKey === teamKey || item.visitKey === teamKey),
-    );
-    return teamKey === game.homeKey
-      ? teamSchedule?.homeLogo
-      : teamSchedule?.visitLogo;
-  };
-
-  const visitLogo = getTeamLogo(game.visitKey);
-  const homeLogo = getTeamLogo(game.homeKey);
-
   return (
     <section className="relative mb-6 rounded-lg bg-kt-black-4 p-12">
       <header className="flex flex-col">
@@ -95,7 +78,7 @@ const BoxScoreItem = ({
       <main className="grid grid-cols-3 gap-2">
         <article className="flex flex-col items-center justify-center gap-2">
           <img
-            src={visitLogo}
+            src={game.visitLogo}
             alt={game.visit}
             className="h-36 w-36 object-contain"
           />
@@ -111,7 +94,7 @@ const BoxScoreItem = ({
 
         <section className="flex flex-col items-center justify-center gap-2">
           <img
-            src={homeLogo}
+            src={game.homeLogo}
             alt={game.home}
             className="h-36 w-36 object-contain"
           />

--- a/src/components/game/boxscore/BoxScoreSkeleton.tsx
+++ b/src/components/game/boxscore/BoxScoreSkeleton.tsx
@@ -1,0 +1,57 @@
+import { motion } from 'framer-motion';
+
+import { BsArrowLeftCircle, BsArrowRightCircle } from 'react-icons/bs';
+
+const BoxScoreSkeleton = () => {
+  return (
+    <motion.section
+      className="relative mb-6 rounded-lg bg-kt-black-4 p-12"
+      animate={{
+        opacity: [1, 0.7, 1],
+        transition: {
+          duration: 1,
+          repeat: Infinity,
+          ease: 'easeInOut',
+        },
+      }}
+    >
+      <header className="flex flex-col">
+        <div className="mb-4 flex items-center justify-between">
+          <div className="w-1/6"></div>
+          <div className="flex w-4/6 items-center justify-center gap-8">
+            <BsArrowLeftCircle size={30} className="text-gray-500" />
+            <div className="h-12 w-52 rounded-md bg-gray-600"></div>
+            <BsArrowRightCircle size={30} className="text-gray-500" />
+          </div>
+          <div className="flex w-1/6 justify-end">
+            <div className="h-10 w-28 rounded-md bg-gray-600"></div>
+          </div>
+        </div>
+        <div className="mx-auto h-4 w-48 rounded-md bg-gray-600"></div>
+      </header>
+
+      <main className="mt-4 grid grid-cols-3 gap-2">
+        <article className="flex flex-col items-center justify-center gap-2">
+          <div className="h-32 w-32 rounded-full bg-gray-600"></div>
+          <div className="h-8 w-10 rounded-md bg-gray-600"></div>
+          <div className="mt-2 h-8 w-20 rounded-md bg-gray-600"></div>
+        </article>
+
+        <div className="flex items-center justify-center">
+          <div className="h-12 w-16 rounded-md bg-gray-600"></div>
+        </div>
+
+        <article className="flex flex-col items-center justify-center gap-2">
+          <div className="h-32 w-32 rounded-full bg-gray-600"></div>
+          <div className="h-8 w-10 rounded-md bg-gray-600"></div>
+          <div className="mt-2 h-8 w-20 rounded-md bg-gray-600"></div>
+        </article>
+        <footer className="col-span-3 mt-2">
+          <div className="h-32 rounded-md bg-gray-600"></div>
+        </footer>
+      </main>
+    </motion.section>
+  );
+};
+
+export default BoxScoreSkeleton;

--- a/src/components/game/boxscore/MainRecordTable.tsx
+++ b/src/components/game/boxscore/MainRecordTable.tsx
@@ -1,12 +1,7 @@
-import {
-  createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+import { createColumnHelper, ColumnDef } from '@tanstack/react-table';
 
 import { EtcGamesType } from '@/types/BoxScoreType';
-import { cn } from '@/utils/cn';
+import { DataTable } from '@/ui/table/DataTable';
 
 type MainRecordTableProps = {
   etcgames: EtcGamesType[];
@@ -23,60 +18,16 @@ const columns = [
     cell: (info) => info.getValue(),
     header: () => '내용',
   }),
-];
+] as ColumnDef<EtcGamesType>[];
 
 const MainRecordTable = ({ etcgames }: MainRecordTableProps) => {
-  const table = useReactTable({
-    data: etcgames,
-    columns,
-    getCoreRowModel: getCoreRowModel(),
-  });
-
   return (
-    <div className="overflow-hidden rounded-md bg-kt-gray-2">
-      <div className="overflow-x-auto">
-        <table className="min-w-full">
-          <thead>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <tr
-                key={headerGroup.id}
-                className="bg-kt-black-5 text-base text-white"
-              >
-                {headerGroup.headers.map((header) => (
-                  <th key={header.id} className="px-6 py-3 text-left">
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </th>
-                ))}
-              </tr>
-            ))}
-          </thead>
-          <tbody className="text-sm font-light text-white">
-            {table.getRowModel().rows.map((row, rowIndex) => (
-              <tr key={row.id}>
-                {row.getVisibleCells().map((cell, index) => (
-                  <td
-                    key={cell.id}
-                    className={cn(
-                      'whitespace-nowrap border-b px-6 py-4',
-                      index === 0 && 'bg-kt-gray-1 font-extrabold',
-                      rowIndex === table.getRowModel().rows.length - 1 &&
-                        'border-b-0',
-                    )}
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+    <DataTable
+      data={etcgames}
+      columns={columns}
+      bodyCellClassName="border-b border-gray-600"
+      headerCellClassName="text-left"
+    />
   );
 };
 

--- a/src/components/game/boxscore/MainRecordTable.tsx
+++ b/src/components/game/boxscore/MainRecordTable.tsx
@@ -1,0 +1,83 @@
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+
+import { EtcGamesType } from '@/types/BoxScoreType';
+import { cn } from '@/utils/cn';
+
+type MainRecordTableProps = {
+  etcgames: EtcGamesType[];
+};
+
+const columnHelper = createColumnHelper<EtcGamesType>();
+
+const columns = [
+  columnHelper.accessor('how', {
+    cell: (info) => info.getValue(),
+    header: () => '구분',
+  }),
+  columnHelper.accessor('result', {
+    cell: (info) => info.getValue(),
+    header: () => '내용',
+  }),
+];
+
+const MainRecordTable = ({ etcgames }: MainRecordTableProps) => {
+  const table = useReactTable({
+    data: etcgames,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <div className="overflow-hidden rounded-md bg-kt-gray-2">
+      <div className="overflow-x-auto">
+        <table className="min-w-full">
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr
+                key={headerGroup.id}
+                className="bg-kt-black-5 text-base text-white"
+              >
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} className="px-6 py-3 text-left">
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody className="text-sm font-light text-white">
+            {table.getRowModel().rows.map((row, rowIndex) => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell, index) => (
+                  <td
+                    key={cell.id}
+                    className={cn(
+                      'whitespace-nowrap border-b px-6 py-4',
+                      index === 0 && 'bg-kt-gray-1 font-extrabold',
+                      rowIndex === table.getRowModel().rows.length - 1 &&
+                        'border-b-0',
+                    )}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default MainRecordTable;

--- a/src/components/game/boxscore/PitcherRecordTable.tsx
+++ b/src/components/game/boxscore/PitcherRecordTable.tsx
@@ -1,0 +1,158 @@
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+
+import { PitchersType } from '@/types/BoxScoreType';
+import { cn } from '@/utils/cn';
+
+type PitcherRecordTableProps = {
+  data: PitchersType[];
+};
+
+const columnHelper = createColumnHelper<PitchersType>();
+
+const columns = [
+  columnHelper.accessor('name', {
+    cell: (info) => info.getValue(),
+    header: () => '선수명',
+  }),
+  columnHelper.accessor('changeinn', {
+    cell: (info) => info.getValue(),
+    header: () => '등판',
+  }),
+  columnHelper.accessor('wls', {
+    cell: (info) => {
+      const value = info.getValue();
+      const wls = {
+        W: '승리',
+        L: '패배',
+        S: '세이브',
+        H: '홀드',
+      };
+      return wls[value as keyof typeof wls] || value;
+    },
+    header: () => '결과',
+  }),
+  columnHelper.accessor('w', {
+    cell: (info) => info.getValue(),
+    header: () => '승',
+  }),
+  columnHelper.accessor('l', {
+    cell: (info) => info.getValue(),
+    header: () => '패',
+  }),
+  columnHelper.accessor('s', {
+    cell: (info) => info.getValue(),
+    header: () => '세',
+  }),
+  columnHelper.accessor('inn', {
+    cell: (info) => info.getValue(),
+    header: () => '이닝',
+  }),
+  columnHelper.accessor('pa', {
+    cell: (info) => info.getValue(),
+    header: () => '타자',
+  }),
+  columnHelper.accessor('bf', {
+    cell: (info) => info.getValue(),
+    header: () => '투구 수',
+  }),
+  columnHelper.accessor('ab', {
+    cell: (info) => info.getValue(),
+    header: () => '타수',
+  }),
+  columnHelper.accessor('hit', {
+    cell: (info) => info.getValue(),
+    header: () => '피안타',
+  }),
+  columnHelper.accessor('hr', {
+    cell: (info) => info.getValue(),
+    header: () => '피홈런',
+  }),
+  columnHelper.accessor('bbhp', {
+    cell: (info) => info.getValue(),
+    header: () => '사구',
+  }),
+  columnHelper.accessor('kk', {
+    cell: (info) => info.getValue(),
+    header: () => '삼진',
+  }),
+  columnHelper.accessor('r', {
+    cell: (info) => info.getValue(),
+    header: () => '실점',
+  }),
+  columnHelper.accessor('er', {
+    cell: (info) => info.getValue(),
+    header: () => '자책',
+  }),
+  columnHelper.accessor(
+    (row) => {
+      const era = (row.accmEr * 9) / (row.accmInn2 / 3);
+      return isNaN(era) ? '-' : era.toFixed(2);
+    },
+    {
+      id: 'era',
+      cell: (info) => info.getValue(),
+      header: () => '평균 자책점',
+    },
+  ),
+];
+
+const PitcherRecordTable = ({ data }: PitcherRecordTableProps) => {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <div className="overflow-hidden rounded-md bg-kt-gray-1">
+      <div className="overflow-x-auto">
+        <table className="min-w-full">
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr
+                key={headerGroup.id}
+                className="bg-kt-red-2 text-base text-white"
+              >
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} className="px-3 py-3 text-center">
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody className="text-sm font-light text-white">
+            {table.getRowModel().rows.map((row, rowIndex) => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <td
+                    key={cell.id}
+                    className={cn(
+                      'whitespace-nowrap border-b border-gray-600 px-3 py-3 text-center',
+                      rowIndex === table.getRowModel().rows.length - 1 &&
+                        'border-b-0',
+                    )}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default PitcherRecordTable;

--- a/src/components/game/boxscore/PitcherRecordTable.tsx
+++ b/src/components/game/boxscore/PitcherRecordTable.tsx
@@ -1,12 +1,7 @@
-import {
-  createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+import { createColumnHelper, ColumnDef } from '@tanstack/react-table';
 
 import { PitchersType } from '@/types/BoxScoreType';
-import { cn } from '@/utils/cn';
+import { DataTable } from '@/ui/table/DataTable';
 
 type PitcherRecordTableProps = {
   data: PitchersType[];
@@ -99,59 +94,15 @@ const columns = [
       header: () => '평균 자책점',
     },
   ),
-];
+] as ColumnDef<PitchersType>[];
 
 const PitcherRecordTable = ({ data }: PitcherRecordTableProps) => {
-  const table = useReactTable({
-    data,
-    columns,
-    getCoreRowModel: getCoreRowModel(),
-  });
-
   return (
-    <div className="overflow-hidden rounded-md bg-kt-gray-1">
-      <div className="overflow-x-auto">
-        <table className="min-w-full">
-          <thead>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <tr
-                key={headerGroup.id}
-                className="bg-kt-red-2 text-base text-white"
-              >
-                {headerGroup.headers.map((header) => (
-                  <th key={header.id} className="px-3 py-3 text-center">
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </th>
-                ))}
-              </tr>
-            ))}
-          </thead>
-          <tbody className="text-sm font-light text-white">
-            {table.getRowModel().rows.map((row, rowIndex) => (
-              <tr key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <td
-                    key={cell.id}
-                    className={cn(
-                      'whitespace-nowrap border-b border-gray-600 px-3 py-3 text-center',
-                      rowIndex === table.getRowModel().rows.length - 1 &&
-                        'border-b-0',
-                    )}
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+    <DataTable
+      data={data}
+      columns={columns}
+      bodyCellClassName="border-b border-gray-600 text-center"
+    />
   );
 };
 

--- a/src/components/game/boxscore/ScoreTable.tsx
+++ b/src/components/game/boxscore/ScoreTable.tsx
@@ -1,11 +1,11 @@
-import {
-  createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+import { createColumnHelper, ColumnDef } from '@tanstack/react-table';
 
 import { BoxScoreScoreBoardType } from '@/types/BoxScoreType';
+import { DataTable } from '@/ui/table/DataTable';
+
+type ScoreTableProps = {
+  scoreBoard: BoxScoreScoreBoardType[];
+};
 
 const columnHelper = createColumnHelper<BoxScoreScoreBoardType>(); // type-safe한 방식으로 column을 생성하기 위한 helper
 
@@ -38,60 +38,17 @@ const columns = [
     cell: (info) => info.getValue(),
     header: () => 'B',
   }),
-];
-
-interface ScoreTableProps {
-  scoreBoard: BoxScoreScoreBoardType[];
-}
+] as ColumnDef<BoxScoreScoreBoardType>[];
 
 const ScoreTable = ({ scoreBoard }: ScoreTableProps) => {
-  // useReactTable hook을 사용하여 table을 생성
-  const table = useReactTable({
-    data: scoreBoard,
-    columns,
-    getCoreRowModel: getCoreRowModel(), // 기본적인 행 모델 생성
-  });
-
   return (
-    <div className="overflow-hidden rounded-md bg-kt-gray-1">
-      <div className="overflow-x-auto">
-        <table className="min-w-full">
-          <thead>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <tr
-                key={headerGroup.id}
-                className="bg-kt-red-2 text-base uppercase text-white"
-              >
-                {headerGroup.headers.map((header) => (
-                  <th key={header.id} className="px-3 py-3 text-center">
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </th>
-                ))}
-              </tr>
-            ))}
-          </thead>
-          <tbody className="text-sm font-light text-white">
-            {table.getRowModel().rows.map((row) => (
-              <tr key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <td
-                    key={cell.id}
-                    className="whitespace-nowrap px-3 py-3 text-center"
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+    <DataTable
+      data={scoreBoard}
+      columns={columns}
+      containerClassName="bg-kt-gray-1 bg-opacity-60"
+      headerRowClassName="bg-opacity-70 uppercase"
+      bodyCellClassName="text-center"
+    />
   );
 };
 

--- a/src/components/game/boxscore/ScoreTable.tsx
+++ b/src/components/game/boxscore/ScoreTable.tsx
@@ -1,0 +1,98 @@
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+
+import { BoxScoreScoreBoardType } from '@/types/BoxScoreType';
+
+const columnHelper = createColumnHelper<BoxScoreScoreBoardType>(); // type-safe한 방식으로 column을 생성하기 위한 helper
+
+// column 정의
+const columns = [
+  // columnHelper.accessor는 데이터 객체의 key를 받아 column을 생성함
+  columnHelper.accessor('bhomeName', {
+    cell: (info) => info.getValue(),
+    header: () => '팀',
+  }),
+  ...Array.from({ length: 9 }, (_, i) =>
+    columnHelper.accessor(`score${i + 1}` as keyof BoxScoreScoreBoardType, {
+      cell: (info) => info.getValue(),
+      header: () => `${i + 1}회`,
+    }),
+  ),
+  columnHelper.accessor('run', {
+    cell: (info) => info.getValue(),
+    header: () => 'R',
+  }),
+  columnHelper.accessor('hit', {
+    cell: (info) => info.getValue(),
+    header: () => 'H',
+  }),
+  columnHelper.accessor('error', {
+    cell: (info) => info.getValue(),
+    header: () => 'E',
+  }),
+  columnHelper.accessor('ballfour', {
+    cell: (info) => info.getValue(),
+    header: () => 'B',
+  }),
+];
+
+interface ScoreTableProps {
+  scoreBoard: BoxScoreScoreBoardType[];
+}
+
+const ScoreTable = ({ scoreBoard }: ScoreTableProps) => {
+  // useReactTable hook을 사용하여 table을 생성
+  const table = useReactTable({
+    data: scoreBoard,
+    columns,
+    getCoreRowModel: getCoreRowModel(), // 기본적인 행 모델 생성
+  });
+
+  return (
+    <div className="overflow-hidden rounded-md bg-kt-gray-1">
+      <div className="overflow-x-auto">
+        <table className="min-w-full">
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr
+                key={headerGroup.id}
+                className="bg-kt-red-2 text-base uppercase text-white"
+              >
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} className="px-3 py-3 text-center">
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody className="text-sm font-light text-white">
+            {table.getRowModel().rows.map((row) => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <td
+                    key={cell.id}
+                    className="whitespace-nowrap px-3 py-3 text-center"
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default ScoreTable;

--- a/src/components/game/boxscore/SectionLayout.tsx
+++ b/src/components/game/boxscore/SectionLayout.tsx
@@ -1,0 +1,18 @@
+type SectionLayoutProps = {
+  title: string;
+  children: React.ReactNode;
+};
+
+const SectionLayout = ({ title, children }: SectionLayoutProps) => {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center">
+        <div className="mr-3 h-6 w-1 bg-kt-red-2"></div>
+        <h2 className="text-xl font-extrabold">{title}</h2>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default SectionLayout;

--- a/src/components/game/schedule/CalendarCell.tsx
+++ b/src/components/game/schedule/CalendarCell.tsx
@@ -35,9 +35,7 @@ const CalendarCell = ({ day, data }: CalendarCellProps) => {
           </div>
           {data && (
             <>
-              <Link
-                to={`/game/boxscore?gameDate=${data.gameDate}&gmkey=${data.gmkey}`}
-              >
+              <Link to={`/game/boxscore?${data.gameDate}&${data.gmkey}`}>
                 <div className="flex flex-grow flex-col items-center justify-center">
                   <img
                     src={data.home === 'KT' ? data.visitLogo : data.homeLogo}

--- a/src/components/game/schedule/CalendarCell.tsx
+++ b/src/components/game/schedule/CalendarCell.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+
 import ResultFlag from './ResultFlag';
 import { KtWizMonthSchedule } from '@/types/ScheduleType';
 import { cn } from '@/utils/cn';
@@ -33,24 +35,28 @@ const CalendarCell = ({ day, data }: CalendarCellProps) => {
           </div>
           {data && (
             <>
-              <div className="flex flex-grow flex-col items-center justify-center">
-                <img
-                  src={data.home === 'KT' ? data.visitLogo : data.homeLogo}
-                  alt={data.home === 'KT' ? data.visit : data.home}
-                  className="h-20 w-20 object-contain"
-                />
-                <div className="flex items-center justify-center gap-2">
-                  <div className="text-sm">{data.gtime}</div>
-                  <div className="text-sm text-red-300">
-                    {data.home === 'KT' ? '수원' : data.stadium}
+              <Link
+                to={`/game/boxscore?gameDate=${data.gameDate}&gmkey=${data.gmkey}`}
+              >
+                <div className="flex flex-grow flex-col items-center justify-center">
+                  <img
+                    src={data.home === 'KT' ? data.visitLogo : data.homeLogo}
+                    alt={data.home === 'KT' ? data.visit : data.home}
+                    className="h-20 w-20 object-contain"
+                  />
+                  <div className="flex items-center justify-center gap-2">
+                    <div className="text-sm">{data.gtime}</div>
+                    <div className="text-sm text-red-300">
+                      {data.home === 'KT' ? '수원' : data.stadium}
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div className="flex justify-center">
-                <div className="text-xs text-gray-200">
-                  {formatBroadcast(data.broadcast)}
+                <div className="flex justify-center">
+                  <div className="text-xs text-gray-200">
+                    {formatBroadcast(data.broadcast)}
+                  </div>
                 </div>
-              </div>
+              </Link>
             </>
           )}
         </div>

--- a/src/components/game/schedule/CalendarHeader.tsx
+++ b/src/components/game/schedule/CalendarHeader.tsx
@@ -2,24 +2,16 @@ import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
 import { FaList, FaRegCalendarAlt } from 'react-icons/fa';
 
 import { cn } from '@/utils/cn';
+import { useScheduleStore } from '@/stores/ScheduleStore';
 
 type CalendarHeaderProps = {
-  year: number;
-  month: number;
   onPrevMonth: () => void;
   onNextMonth: () => void;
-  viewType: 'calendar' | 'list';
-  setViewType: (viewType: 'calendar' | 'list') => void;
 };
 
-const CalendarHeader = ({
-  year,
-  month,
-  onPrevMonth,
-  onNextMonth,
-  viewType,
-  setViewType,
-}: CalendarHeaderProps) => {
+const CalendarHeader = ({ onPrevMonth, onNextMonth }: CalendarHeaderProps) => {
+  const { year, month, viewType, setViewType } = useScheduleStore();
+
   return (
     <header className="mb-4 flex items-center justify-between">
       <nav className="flex items-center gap-5">

--- a/src/components/game/schedule/CalendarView.tsx
+++ b/src/components/game/schedule/CalendarView.tsx
@@ -1,19 +1,17 @@
 import { useEffect, useState } from 'react';
+
 import { motion } from 'framer-motion';
 
 import CalendarCell from './CalendarCell';
+import CalendarSkeleton from './CalendarSkeleton';
 import { useCalendarGenerate } from '@/hooks/useCalendarGenerate';
 import { GetMonthSchedule } from '@/api/GetMonthSchedule';
 import { KtWizMonthSchedule } from '@/types/ScheduleType';
-import CalendarSkeleton from './CalendarSkeleton';
+import { useScheduleStore } from '@/stores/ScheduleStore';
 
-type CalendarViewProps = {
-  year: number;
-  month: number;
-};
-
-const CalendarView = ({ year, month }: CalendarViewProps) => {
+const CalendarView = () => {
   const [showSkeleton, setShowSkeleton] = useState(true);
+  const { year, month } = useScheduleStore();
   const { days, weekdays } = useCalendarGenerate(year, month);
   const { data, isLoading, isError, error } = GetMonthSchedule(year, month);
 

--- a/src/components/game/schedule/ListView.tsx
+++ b/src/components/game/schedule/ListView.tsx
@@ -7,14 +7,11 @@ import { useCalendarGenerate } from '@/hooks/useCalendarGenerate';
 import { cn } from '@/utils/cn';
 import { GetMonthSchedule } from '@/api/GetMonthSchedule';
 import { KtWizMonthSchedule } from '@/types/ScheduleType';
+import { useScheduleStore } from '@/stores/ScheduleStore';
 
-type ListViewProps = {
-  year: number;
-  month: number;
-};
-
-const ListView = ({ year, month }: ListViewProps) => {
+const ListView = () => {
   const [showSkeleton, setShowSkeleton] = useState(true);
+  const { year, month } = useScheduleStore();
   const { flatDays } = useCalendarGenerate(year, month);
   const { data, isLoading, isError, error } = GetMonthSchedule(year, month);
 

--- a/src/components/game/schedule/ListView.tsx
+++ b/src/components/game/schedule/ListView.tsx
@@ -123,9 +123,7 @@ const ListView = () => {
                   {game.outcome}
                 </span>
 
-                <Link
-                  to={`/game/boxscore?gameDate=${game.gameDate}&gmkey=${game.gmkey}`}
-                >
+                <Link to={`/game/boxscore?${game.gameDate}&${game.gmkey}`}>
                   <button className="text-base text-gray-200 transition-colors duration-200 hover:text-gray-400">
                     상세 보기
                   </button>

--- a/src/components/game/schedule/ListView.tsx
+++ b/src/components/game/schedule/ListView.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 
 import { motion } from 'framer-motion';
+import { Link } from 'react-router-dom';
 
 import ListSkeleton from './ListSkeleton';
 import { useCalendarGenerate } from '@/hooks/useCalendarGenerate';
@@ -121,9 +122,14 @@ const ListView = () => {
                 >
                   {game.outcome}
                 </span>
-                <button className="text-base text-gray-200 transition-colors duration-200 hover:text-gray-400">
-                  상세 보기
-                </button>
+
+                <Link
+                  to={`/game/boxscore?gameDate=${game.gameDate}&gmkey=${game.gmkey}`}
+                >
+                  <button className="text-base text-gray-200 transition-colors duration-200 hover:text-gray-400">
+                    상세 보기
+                  </button>
+                </Link>
               </div>
             </div>
           </motion.div>

--- a/src/components/home/contents/schedule/ScheduleItem.tsx
+++ b/src/components/home/contents/schedule/ScheduleItem.tsx
@@ -139,9 +139,7 @@ const ScheduleItem = ({ game, isFirstUpcoming }: ScheduleItemProps) => {
       </div>
 
       <HoverOverlay>
-        <Link
-          to={`/game/boxscore?gameDate=${game.gameDate}&gmkey=${game.gmkey}`}
-        >
+        <Link to={`/game/boxscore?${game.gameDate}&${game.gmkey}`}>
           <Button
             variant={isActive ? 'secondary' : 'primary'}
             size="large"

--- a/src/components/home/contents/schedule/ScheduleItem.tsx
+++ b/src/components/home/contents/schedule/ScheduleItem.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { LuCalendarDays } from 'react-icons/lu';
 import { IoLocationOutline } from 'react-icons/io5';
 
@@ -138,13 +139,17 @@ const ScheduleItem = ({ game, isFirstUpcoming }: ScheduleItemProps) => {
       </div>
 
       <HoverOverlay>
-        <Button
-          variant={isActive ? 'secondary' : 'primary'}
-          size="large"
-          className="hover:scale-105"
+        <Link
+          to={`/game/boxscore?gameDate=${game.gameDate}&gmkey=${game.gmkey}`}
         >
-          경기 정보
-        </Button>
+          <Button
+            variant={isActive ? 'secondary' : 'primary'}
+            size="large"
+            className="hover:scale-105"
+          >
+            경기 정보
+          </Button>
+        </Link>
       </HoverOverlay>
     </article>
   );

--- a/src/pages/Game/BoxScorePage.tsx
+++ b/src/pages/Game/BoxScorePage.tsx
@@ -2,6 +2,9 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import BoxScoreItem from '@/components/game/boxscore/BoxScoreItem';
 import BoxScoreSkeleton from '@/components/game/boxscore/BoxScoreSkeleton';
+import MainRecordTable from '@/components/game/boxscore/MainRecordTable';
+import BatterRecordTable from '@/components/game/boxscore/BatterRecordTable';
+import PitcherRecordTable from '@/components/game/boxscore/PitcherRecordTable';
 import { GetBoxScore } from '@/api/GetBoxScore';
 import { GetMonthSchedule } from '@/api/GetMonthSchedule';
 import { useScheduleStore } from '@/stores/ScheduleStore';
@@ -55,22 +58,55 @@ const BoxScorePage = () => {
 
   return (
     <div className="mx-10 p-10">
-      <h1 className="mb-5 text-2xl font-extrabold">해당 경기 정보</h1>
-      {isLoading ? (
-        <BoxScoreSkeleton />
-      ) : (
-        boxScoreData?.data && (
-          <BoxScoreItem
-            game={boxScoreData.data.schedule.current}
-            logo={monthScheduleData?.data.list || []}
-            scoreBoard={boxScoreData.data.scoreboard}
-            onNextGame={handleNextGame}
-            onPrevGame={handlePrevGame}
-            hasNextGame={!!boxScoreData.data.schedule.next}
-            hasPrevGame={!!boxScoreData.data.schedule.prev}
-          />
-        )
-      )}
+      <div className="flex flex-col gap-12">
+        <h1 className="text-2xl font-extrabold">해당 경기 정보</h1>
+        {isLoading ? (
+          <BoxScoreSkeleton />
+        ) : (
+          boxScoreData?.data && (
+            <BoxScoreItem
+              game={boxScoreData.data.schedule.current}
+              logo={monthScheduleData?.data.list || []}
+              scoreBoard={boxScoreData.data.scoreboard}
+              onNextGame={handleNextGame}
+              onPrevGame={handlePrevGame}
+              hasNextGame={!!boxScoreData.data.schedule.next}
+              hasPrevGame={!!boxScoreData.data.schedule.prev}
+            />
+          )
+        )}
+
+        <div className="flex flex-col gap-4">
+          <h2 className="text-2xl font-extrabold">주요 기록</h2>
+          <MainRecordTable etcgames={boxScoreData.data.etcgames} />
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <h2 className="text-2xl font-extrabold">
+            {boxScoreData.data.schedule.current.home} 타자 기록
+          </h2>
+          <BatterRecordTable data={boxScoreData.data.hbatters} />
+        </div>
+        <div className="flex flex-col gap-4">
+          <h2 className="text-2xl font-extrabold">
+            {boxScoreData.data.schedule.current.visit} 타자 기록
+          </h2>
+          <BatterRecordTable data={boxScoreData.data.vbatters} />
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <h2 className="text-2xl font-extrabold">
+            {boxScoreData.data.schedule.current.home} 투수 기록
+          </h2>
+          <PitcherRecordTable data={boxScoreData.data.hpitchers} />
+        </div>
+        <div className="flex flex-col gap-4">
+          <h2 className="text-2xl font-extrabold">
+            {boxScoreData.data.schedule.current.visit} 투수 기록
+          </h2>
+          <PitcherRecordTable data={boxScoreData.data.vpitchers} />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/Game/BoxScorePage.tsx
+++ b/src/pages/Game/BoxScorePage.tsx
@@ -1,6 +1,7 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import BoxScoreItem from '@/components/game/boxscore/BoxScoreItem';
+import BoxScoreSkeleton from '@/components/game/boxscore/BoxScoreSkeleton';
 import { GetBoxScore } from '@/api/GetBoxScore';
 import { GetMonthSchedule } from '@/api/GetMonthSchedule';
 import { useScheduleStore } from '@/stores/ScheduleStore';
@@ -55,16 +56,20 @@ const BoxScorePage = () => {
   return (
     <div className="mx-10 p-10">
       <h1 className="mb-5 text-2xl font-extrabold">해당 경기 정보</h1>
-      {boxScoreData?.data && (
-        <BoxScoreItem
-          game={boxScoreData.data.schedule.current}
-          logo={monthScheduleData?.data.list || []}
-          scoreBoard={boxScoreData.data.scoreboard}
-          onNextGame={handleNextGame}
-          onPrevGame={handlePrevGame}
-          hasNextGame={!!boxScoreData.data.schedule.next}
-          hasPrevGame={!!boxScoreData.data.schedule.prev}
-        />
+      {isLoading ? (
+        <BoxScoreSkeleton />
+      ) : (
+        boxScoreData?.data && (
+          <BoxScoreItem
+            game={boxScoreData.data.schedule.current}
+            logo={monthScheduleData?.data.list || []}
+            scoreBoard={boxScoreData.data.scoreboard}
+            onNextGame={handleNextGame}
+            onPrevGame={handlePrevGame}
+            hasNextGame={!!boxScoreData.data.schedule.next}
+            hasPrevGame={!!boxScoreData.data.schedule.prev}
+          />
+        )
       )}
     </div>
   );

--- a/src/pages/Game/BoxScorePage.tsx
+++ b/src/pages/Game/BoxScorePage.tsx
@@ -1,8 +1,72 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import BoxScoreItem from '@/components/game/boxscore/BoxScoreItem';
+import { GetBoxScore } from '@/api/GetBoxScore';
+import { GetMonthSchedule } from '@/api/GetMonthSchedule';
+import { useScheduleStore } from '@/stores/ScheduleStore';
+
 const BoxScorePage = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { year, month } = useScheduleStore();
+
+  // 쿼리 파라미터 파싱
+  const [gameDate, gmkey] = location.search.substring(1).split('&');
+
+  const { data: monthScheduleData } = GetMonthSchedule(year, month);
+
+  // 가장 최근에 완료된 경기 찾기
+  const lastFinishedGame = monthScheduleData?.data.list
+    .filter((game) => game.status === '3')
+    .pop();
+
+  // gameDate나 gmkey가 없을 경우 가장 최근 경기 데이터 사용
+  const finalGameDate = parseInt(
+    String(gameDate || lastFinishedGame?.gameDate || '0'),
+  );
+  const finalGmkey = gmkey || lastFinishedGame?.gmkey || '';
+
+  const {
+    data: boxScoreData,
+    isLoading,
+    error,
+  } = GetBoxScore(finalGameDate, finalGmkey);
+
+  if (error) return <div>Error: {error}</div>;
+  if (!boxScoreData?.data && !isLoading)
+    return <div>정보가 존재하지 않습니다.</div>;
+
+  const handleNextGame = () => {
+    if (boxScoreData?.data.schedule.next) {
+      const { gameDate: nextGameDate, gmkey: nextGmkey } =
+        boxScoreData.data.schedule.next;
+      navigate(`/game/boxscore?${nextGameDate}&${nextGmkey}`);
+    }
+  };
+
+  const handlePrevGame = () => {
+    if (boxScoreData?.data.schedule.prev) {
+      const { gameDate: prevGameDate, gmkey: prevGmkey } =
+        boxScoreData.data.schedule.prev;
+      navigate(`/game/boxscore?${prevGameDate}&${prevGmkey}`);
+    }
+  };
+
   return (
-    <>
-      <h1>BoxScore Page</h1>
-    </>
+    <div className="mx-10 p-10">
+      <h1 className="mb-5 text-2xl font-extrabold">해당 경기 정보</h1>
+      {boxScoreData?.data && (
+        <BoxScoreItem
+          game={boxScoreData.data.schedule.current}
+          logo={monthScheduleData?.data.list || []}
+          scoreBoard={boxScoreData.data.scoreboard}
+          onNextGame={handleNextGame}
+          onPrevGame={handlePrevGame}
+          hasNextGame={!!boxScoreData.data.schedule.next}
+          hasPrevGame={!!boxScoreData.data.schedule.prev}
+        />
+      )}
+    </div>
   );
 };
 

--- a/src/pages/Game/BoxScorePage.tsx
+++ b/src/pages/Game/BoxScorePage.tsx
@@ -59,22 +59,23 @@ const BoxScorePage = () => {
   return (
     <div className="mx-10 p-10">
       <div className="flex flex-col gap-12">
-        <h1 className="text-2xl font-extrabold">해당 경기 정보</h1>
-        {isLoading ? (
-          <BoxScoreSkeleton />
-        ) : (
-          boxScoreData?.data && (
-            <BoxScoreItem
-              game={boxScoreData.data.schedule.current}
-              logo={monthScheduleData?.data.list || []}
-              scoreBoard={boxScoreData.data.scoreboard}
-              onNextGame={handleNextGame}
-              onPrevGame={handlePrevGame}
-              hasNextGame={!!boxScoreData.data.schedule.next}
-              hasPrevGame={!!boxScoreData.data.schedule.prev}
-            />
-          )
-        )}
+        <div className="flex flex-col gap-4">
+          <h1 className="text-2xl font-extrabold">해당 경기 정보</h1>
+          {isLoading ? (
+            <BoxScoreSkeleton />
+          ) : (
+            boxScoreData?.data && (
+              <BoxScoreItem
+                game={boxScoreData.data.schedule.current}
+                scoreBoard={boxScoreData.data.scoreboard}
+                onNextGame={handleNextGame}
+                onPrevGame={handlePrevGame}
+                hasNextGame={!!boxScoreData.data.schedule.next}
+                hasPrevGame={!!boxScoreData.data.schedule.prev}
+              />
+            )
+          )}
+        </div>
 
         <div className="flex flex-col gap-4">
           <h2 className="text-2xl font-extrabold">주요 기록</h2>

--- a/src/pages/Game/BoxScorePage.tsx
+++ b/src/pages/Game/BoxScorePage.tsx
@@ -5,6 +5,7 @@ import BoxScoreSkeleton from '@/components/game/boxscore/BoxScoreSkeleton';
 import MainRecordTable from '@/components/game/boxscore/MainRecordTable';
 import BatterRecordTable from '@/components/game/boxscore/BatterRecordTable';
 import PitcherRecordTable from '@/components/game/boxscore/PitcherRecordTable';
+import SectionLayout from '@/components/game/boxscore/SectionLayout';
 import { GetBoxScore } from '@/api/GetBoxScore';
 import { GetMonthSchedule } from '@/api/GetMonthSchedule';
 import { useScheduleStore } from '@/stores/ScheduleStore';
@@ -59,8 +60,7 @@ const BoxScorePage = () => {
   return (
     <div className="mx-10 p-10">
       <div className="flex flex-col gap-12">
-        <div className="flex flex-col gap-4">
-          <h1 className="text-2xl font-extrabold">해당 경기 정보</h1>
+        <SectionLayout title="해당 경기 정보">
           {isLoading ? (
             <BoxScoreSkeleton />
           ) : (
@@ -75,38 +75,37 @@ const BoxScorePage = () => {
               />
             )
           )}
-        </div>
+        </SectionLayout>
 
-        <div className="flex flex-col gap-4">
-          <h2 className="text-2xl font-extrabold">주요 기록</h2>
+        {/* 주요 기록 */}
+        <SectionLayout title="주요 기록">
           <MainRecordTable etcgames={boxScoreData.data.etcgames} />
-        </div>
+        </SectionLayout>
 
-        <div className="flex flex-col gap-4">
-          <h2 className="text-2xl font-extrabold">
-            {boxScoreData.data.schedule.current.home} 타자 기록
-          </h2>
+        {/* 타자 기록 */}
+        <SectionLayout
+          title={`${boxScoreData.data.schedule.current.home} 타자 기록`}
+        >
           <BatterRecordTable data={boxScoreData.data.hbatters} />
-        </div>
-        <div className="flex flex-col gap-4">
-          <h2 className="text-2xl font-extrabold">
-            {boxScoreData.data.schedule.current.visit} 타자 기록
-          </h2>
+        </SectionLayout>
+        <SectionLayout
+          title={`${boxScoreData.data.schedule.current.visit} 타자 기록`}
+        >
           <BatterRecordTable data={boxScoreData.data.vbatters} />
-        </div>
+        </SectionLayout>
 
-        <div className="flex flex-col gap-4">
-          <h2 className="text-2xl font-extrabold">
-            {boxScoreData.data.schedule.current.home} 투수 기록
-          </h2>
+        {/* 투수 기록 */}
+        <SectionLayout
+          title={`${boxScoreData.data.schedule.current.home} 투수 기록`}
+        >
           <PitcherRecordTable data={boxScoreData.data.hpitchers} />
-        </div>
-        <div className="flex flex-col gap-4">
-          <h2 className="text-2xl font-extrabold">
-            {boxScoreData.data.schedule.current.visit} 투수 기록
-          </h2>
+        </SectionLayout>
+
+        <SectionLayout
+          title={`${boxScoreData.data.schedule.current.visit} 투수 기록`}
+        >
           <PitcherRecordTable data={boxScoreData.data.vpitchers} />
-        </div>
+        </SectionLayout>
       </div>
     </div>
   );

--- a/src/pages/Game/SchedulePage.tsx
+++ b/src/pages/Game/SchedulePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useRef } from 'react';
 
 import { motion, useInView } from 'framer-motion';
 
@@ -6,11 +6,10 @@ import ScheduleCarousel from '@/components/home/contents/schedule/ScheduleCarous
 import CalendarHeader from '@/components/game/schedule/CalendarHeader';
 import CalendarView from '@/components/game/schedule/CalendarView';
 import ListView from '@/components/game/schedule/ListView';
+import { useScheduleStore } from '@/stores/ScheduleStore';
 
 const SchedulePage = () => {
-  const [year, setYear] = useState<number>(new Date().getFullYear());
-  const [month, setMonth] = useState<number>(new Date().getMonth() + 1);
-  const [viewType, setViewType] = useState<'calendar' | 'list'>('calendar');
+  const { year, month, setYear, setMonth, viewType } = useScheduleStore();
 
   const ref = useRef<HTMLDivElement | null>(null);
   const isInView = useInView(ref, {
@@ -51,19 +50,11 @@ const SchedulePage = () => {
 
       <div className="mx-auto w-full py-14 pb-4 text-white">
         <CalendarHeader
-          year={year}
-          month={month}
           onPrevMonth={handlePrevMonth}
           onNextMonth={handleNextMonth}
-          viewType={viewType}
-          setViewType={setViewType}
         />
 
-        {viewType === 'calendar' ? (
-          <CalendarView year={year} month={month} />
-        ) : (
-          <ListView year={year} month={month} />
-        )}
+        {viewType === 'calendar' ? <CalendarView /> : <ListView />}
       </div>
 
       <div className="flex justify-end">

--- a/src/stores/ScheduleStore.ts
+++ b/src/stores/ScheduleStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+type ScheduleStoreType = {
+  year: number;
+  month: number;
+  setYear: (year: number) => void;
+  setMonth: (month: number) => void;
+  viewType: 'calendar' | 'list';
+  setViewType: (viewType: 'calendar' | 'list') => void;
+};
+
+const useScheduleStore = create<ScheduleStoreType>((set) => ({
+  year: new Date().getFullYear(),
+  month: new Date().getMonth() + 1,
+  setYear: (year) => set({ year }),
+  setMonth: (month) => set({ month }),
+  viewType: 'calendar',
+  setViewType: (viewType) => set({ viewType }),
+}));
+
+export { useScheduleStore };

--- a/src/types/BoxScoreType.ts
+++ b/src/types/BoxScoreType.ts
@@ -12,11 +12,13 @@ export type BoxScoreGameScheduleType = {
   gyear: string;
   home: string;
   homeKey: string;
+  homeLogo: string;
   hscore: number;
   stadium: string;
   stadiumKey: string;
   visit: string;
   visitKey: string;
+  visitLogo: string;
   vscore: number;
 };
 

--- a/src/types/BoxScoreType.ts
+++ b/src/types/BoxScoreType.ts
@@ -1,0 +1,44 @@
+// 박스스코어 스케줄 타입
+export type BoxScoreGameScheduleType = {
+  broadcast: string;
+  cancelFlag: string; // '0' | '1'?
+  crowdCn: number;
+  endFlag: string;
+  gameDate: number;
+  gday: number;
+  gmkey: string;
+  gmonth: number;
+  gtime: string;
+  gyear: string;
+  home: string;
+  homeKey: string;
+  hscore: number;
+  stadium: string;
+  stadiumKey: string;
+  visit: string;
+  visitKey: string;
+  vscore: number;
+};
+
+// 박스스코어 scoreboard 타입
+export type BoxScoreScoreBoardType = {
+  ballfour: string;
+  bhome: number;
+  bhomeName: string;
+  error: string;
+  gameDate: number;
+  hit: string;
+  run: string;
+  score1: string;
+  score10: string;
+  score11: string;
+  score12: string;
+  score2: string;
+  score3: string;
+  score4: string;
+  score5: string;
+  score6: string;
+  score7: string;
+  score8: string;
+  score9: string;
+};

--- a/src/types/BoxScoreType.ts
+++ b/src/types/BoxScoreType.ts
@@ -42,3 +42,66 @@ export type BoxScoreScoreBoardType = {
   score8: string;
   score9: string;
 };
+
+// 주요 기록 타입
+export type EtcGamesType = {
+  gday: string;
+  gmkey: string;
+  how: string;
+  result: string;
+  seq: number;
+};
+
+// 타자 기록
+export type BattersType = {
+  accmAb: number; // accmHit / accmAb = 타율
+  accmHit: number;
+  changeinn: string;
+  gday: string;
+  gmkey: string;
+  inn1: string;
+  inn2: string;
+  inn3: string;
+  inn4: string;
+  inn5: string;
+  inn6: string;
+  inn7: string;
+  inn8: string;
+  inn9: string;
+  name: string;
+  hit: number; // 안타
+  rbi: number; // 타점
+  run: number; // 득점
+  ab: number; // 타수
+  oneturn: string; // 타순
+  tb: string;
+  pcode: string;
+  position: string;
+};
+
+// 투수 기록
+export type PitchersType = {
+  ab: number; // 타수
+  accmEr: number; // 누적 자책점
+  accmInn2: number; // 누적 이닝
+  // 평균 자책점 계산 방법: (accmEr*9) / (accmInn2/3)
+  changeinn: string; // 교체 이닝
+  bbhp: number; // 사구
+  bf: number; // 투구 수
+  er: number; // 자책점
+  game: number; // 경기 수
+  gday: string;
+  gmkey: string;
+  hit: number; // 피안타
+  hr: number; // 피홈런
+  inn: number; // 이닝
+  kk: number; // 탈삼진
+  l: number; // 패배
+  w: number; // 승리
+  name: string; // 이름
+  pa: number; // 타자 수
+  pcode: string; // 선수 코드
+  s: number; // 세이브
+  r: number; // 실점
+  wls: 'W' | 'L' | 'S' | 'H' | null; // 승리, 패배, 세이브, 홀드
+};

--- a/src/ui/table/DataTable.tsx
+++ b/src/ui/table/DataTable.tsx
@@ -36,21 +36,24 @@ const DataTable = <T extends object>({
 
   return (
     <div className={cn('overflow-hidden rounded-t-md', containerClassName)}>
-      <div className="overflow-x-auto">
-        <table className="min-w-full">
-          <thead>
+      <div className="max-h-[400px] overflow-x-auto">
+        <table className="relative min-w-full">
+          <thead className="sticky top-0 z-10">
             {table.getHeaderGroups().map((headerGroup) => (
               <tr
                 key={headerGroup.id}
                 className={cn(
-                  'bg-kt-red-2 bg-opacity-40 text-base text-white',
+                  'bg-kt-red-2 bg-opacity-40 text-base text-white backdrop-blur-md',
                   headerRowClassName,
                 )}
               >
                 {headerGroup.headers.map((header) => (
                   <th
                     key={header.id}
-                    className={cn('px-3 py-3', headerCellClassName)}
+                    className={cn(
+                      'sticky top-0 px-3 py-3',
+                      headerCellClassName,
+                    )}
                   >
                     {header.isPlaceholder
                       ? null

--- a/src/ui/table/DataTable.tsx
+++ b/src/ui/table/DataTable.tsx
@@ -1,0 +1,93 @@
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+
+import { cn } from '@/utils/cn';
+
+type CellValue = string | number | boolean | null | undefined;
+
+type DataTableProps<T extends object> = {
+  data: T[];
+  columns: ColumnDef<T, CellValue>[];
+  containerClassName?: string;
+  headerRowClassName?: string;
+  headerCellClassName?: string;
+  bodyClassName?: string;
+  bodyCellClassName?: string;
+};
+
+const DataTable = <T extends object>({
+  data,
+  columns,
+  containerClassName,
+  headerRowClassName,
+  headerCellClassName,
+  bodyClassName,
+  bodyCellClassName,
+}: DataTableProps<T>) => {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <div className={cn('overflow-hidden rounded-t-md', containerClassName)}>
+      <div className="overflow-x-auto">
+        <table className="min-w-full">
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr
+                key={headerGroup.id}
+                className={cn(
+                  'bg-kt-red-2 bg-opacity-40 text-base text-white',
+                  headerRowClassName,
+                )}
+              >
+                {headerGroup.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    className={cn('px-3 py-3', headerCellClassName)}
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody
+            className={cn('text-sm font-light text-gray-100', bodyClassName)}
+          >
+            {table.getRowModel().rows.map((row) => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell, index) => (
+                  <td
+                    key={cell.id}
+                    className={cn(
+                      'whitespace-nowrap px-3 py-3',
+                      index === 0 &&
+                        'bg-kt-gray-1 bg-opacity-80 font-extrabold',
+                      bodyCellClassName,
+                    )}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export { DataTable };


### PR DESCRIPTION
## ⚾️ Related Issues

- close #34 

## 📝 Task Details

- `tanstack/react-table`을 사용하여 다량의 데이터를 받아옵니다.
- 메인페이지에서 리그 일정 축약형에서 `경기 정보`를 클릭하면 박스스코어 페이지로 이동합니다.
- game 페이지에서 정규 리그 일정에서 `경기 정보`를 클릭하면 박스스코어 페이지로 이동합니다.
- 달력형에서 각 `셀`을 클릭하면 박스스코어 페이지로 이동합니다.
- 리스트형에서 `상세 보기`를 클릭하면 박스스코어 페이지로 이동합니다.
- 박스스코어 페이지의 테이블을 구성합니다.
- 양 팀의 `투수`, `타자`에 대한 기록 및 `주요 기록`과 `이닝 별 기록`이 표시됩니다.
- 테이블은 사용자 경험을 위해서 헤드부분은 고정 후 스크롤링이 가능하게 합니다.
- 박스스코어 메인에서 좌우 화살표를 클릭 시 `전날` 및 `다음날` 데이터가 렌더링됩니다.
- `해당 경기 정보`의 `스켈레톤`을 구현합니다.

## 📂 References

https://github.com/user-attachments/assets/951fd708-8dda-451a-84d1-2a907fa72d06

## 💕 Review Requirements

- 오전 스크럼 때 보여드렸던 것에서 테이블 스타일을 반영하였습니다.
- 쿼리 파라미터에 `gameDate`값과 `gmkey`값을 통해서 다음 경기 및 이전 경기로 이동합니다.