### PR TITLE
[FEAT] 관전포인트 페이지를 퍼블리싱합니다.

### DIFF
--- a/src/api/GetWatchPoint.ts
+++ b/src/api/GetWatchPoint.ts
@@ -1,0 +1,122 @@
+import { useAxios } from '@/hooks/useAxios';
+
+import {
+  WatchPointGameScoreType,
+  WatchPointScheduleType,
+  WatchPointTeamRankType,
+  WatchPointVsRecordType,
+} from '@/types/WatchPointType';
+
+interface WatchPointData {
+  gameScore: WatchPointGameScoreType;
+  schedule: {
+    current: WatchPointScheduleType;
+    next: WatchPointScheduleType;
+    prev: WatchPointScheduleType;
+  };
+  homeTeamRank: WatchPointTeamRankType;
+  visitTeamRank: WatchPointTeamRankType;
+  homeTeamWinLose: WatchPointVsRecordType;
+  visitTeamWinLose: WatchPointVsRecordType;
+}
+
+interface GetWatchPointResponse {
+  data: WatchPointData;
+}
+
+const gameScoreInitialState: WatchPointGameScoreType = {
+  bhomeName: '',
+  displayDate: '',
+  endFlag: '',
+  gameDate: 0,
+  gmKey: '',
+  gtime: '',
+  hOutcome: '',
+  home: '',
+  homeKey: '',
+  homeLogo: '',
+  hpcode: '',
+  hpitcherName: '',
+  hscore: 0,
+  stadium: '',
+  stadiumKey: '',
+  vOutcome: '',
+  visit: '',
+  visitKey: '',
+  visitLogo: '',
+  vpcode: '',
+  vpitcherName: '',
+  vscore: 0,
+};
+
+const scheduleInitialState: WatchPointScheduleType = {
+  broadcast: '',
+  cancelFlag: '',
+  crowdCn: 0,
+  endFlag: '',
+  gameDate: 0,
+  gday: 0,
+  gmkey: '',
+  gmonth: 0,
+  gtime: '',
+  gyear: '',
+  home: '',
+  homeKey: '',
+  hscore: 0,
+  stadium: '',
+  stadiumKey: '',
+  visit: '',
+  visitKey: '',
+  vscore: 0,
+};
+
+const teamRankInitialState: WatchPointTeamRankType = {
+  ab: 0,
+  bra: '',
+  continue1: '',
+  drawn: 0,
+  era: '',
+  lastrank: 0,
+  lose: 0,
+  rank: 0,
+  teamName: '',
+  teamCode: '',
+  win: 0,
+  wra: '',
+  hra: '',
+};
+
+const vsRecordInitialState: WatchPointVsRecordType = {
+  drawn: 0,
+  lose: 0,
+  win: 0,
+  teamCode: '',
+  teamName: '',
+  vsTeamCode: '',
+};
+
+const GetWatchPoint = (gameDate: number, gmkey: string) => {
+  const { data, isLoading, isError, error } = useAxios<GetWatchPointResponse>({
+    method: 'GET',
+    url: `/game/watchpoint?gameDate=${gameDate}&gmkey=${gmkey}`,
+    initialData: {
+      data: {
+        gameScore: gameScoreInitialState,
+        schedule: {
+          current: scheduleInitialState,
+          next: scheduleInitialState,
+          prev: scheduleInitialState,
+        },
+        homeTeamRank: teamRankInitialState,
+        visitTeamRank: teamRankInitialState,
+        homeTeamWinLose: vsRecordInitialState,
+        visitTeamWinLose: vsRecordInitialState,
+      },
+    },
+    shouldFetchOnMount: true,
+  });
+
+  return { data, isLoading, isError, error };
+};
+
+export { GetWatchPoint };

--- a/src/components/game/watchpoint/AnimateStat.tsx
+++ b/src/components/game/watchpoint/AnimateStat.tsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react';
+
+type AnimatedStatProps = {
+  label: string;
+  leftValue: string;
+  rightValue: string;
+};
+
+const AnimatedStat = ({ label, leftValue, rightValue }: AnimatedStatProps) => {
+  const [leftWidth, setLeftWidth] = useState(0);
+  const [rightWidth, setRightWidth] = useState(0);
+
+  useEffect(() => {
+    const leftNum = parseFloat(leftValue);
+    const rightNum = parseFloat(rightValue);
+    const total = leftNum + rightNum;
+    const leftPercentage = (leftNum / total) * 100;
+    const rightPercentage = (rightNum / total) * 100;
+
+    setLeftWidth(0);
+    setRightWidth(0);
+
+    const timer = setTimeout(() => {
+      setLeftWidth(leftPercentage);
+      setRightWidth(rightPercentage);
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [leftValue, rightValue]);
+
+  return (
+    <div className="mb-4">
+      <div className="mb-1 flex items-center">
+        <div className="w-1/3 text-left">{leftValue}</div>
+        <div className="w-1/3 text-center">
+          <span className="text-gray-300">{label}</span>
+        </div>
+        <div className="w-1/3 text-right">{rightValue}</div>
+      </div>
+      <div className="relative h-2 overflow-hidden rounded-full bg-gray-700">
+        <div
+          className="absolute left-0 top-0 h-full bg-kt-blue transition-all duration-1000 ease-out"
+          style={{ width: `${leftWidth}%` }}
+        ></div>
+        <div
+          className="absolute right-0 top-0 h-full bg-kt-red-3 transition-all duration-1000 ease-out"
+          style={{ width: `${rightWidth}%` }}
+        ></div>
+      </div>
+    </div>
+  );
+};
+
+export default AnimatedStat;

--- a/src/components/game/watchpoint/WatchPointItem.tsx
+++ b/src/components/game/watchpoint/WatchPointItem.tsx
@@ -1,0 +1,144 @@
+import { BsArrowLeftCircle, BsArrowRightCircle } from 'react-icons/bs';
+
+import AnimatedStat from './AnimateStat';
+import {
+  WatchPointGameScoreType,
+  WatchPointTeamRankType,
+  WatchPointVsRecordType,
+} from '@/types/WatchPointType';
+import { cn } from '@/utils/cn';
+
+type WatchPointItemProps = {
+  game: WatchPointGameScoreType;
+  homeGameRecord: WatchPointTeamRankType;
+  awayGameRecord: WatchPointTeamRankType;
+  homeVsRecord: WatchPointVsRecordType;
+  awayVsRecord: WatchPointVsRecordType;
+  onNextGame: () => void;
+  onPrevGame: () => void;
+  hasNextGame: boolean;
+  hasPrevGame: boolean;
+};
+const WatchPointItem = ({
+  game,
+  homeGameRecord,
+  awayGameRecord,
+  homeVsRecord,
+  awayVsRecord,
+  onNextGame,
+  onPrevGame,
+  hasNextGame,
+  hasPrevGame,
+}: WatchPointItemProps) => {
+  return (
+    <section className="relative mb-6 rounded-lg bg-kt-black-4 p-8">
+      <header className="mb-4 flex flex-col">
+        <div className="mb-2 flex items-center justify-between">
+          <div className="w-1/6"></div>
+          <div className="flex w-4/6 items-center justify-center gap-8">
+            <button
+              aria-label="이전 날짜"
+              className={cn(
+                'text-white',
+                !hasPrevGame
+                  ? 'cursor-not-allowed text-gray-500'
+                  : 'transition-colors duration-200 hover:text-rose-400',
+              )}
+              onClick={onPrevGame}
+              disabled={!hasPrevGame}
+            >
+              <BsArrowLeftCircle size={30} />
+            </button>
+            <span className="text-3xl font-semibold">{game.displayDate}</span>
+            <button
+              aria-label="다음 날짜"
+              className={cn(
+                'text-white',
+                !hasNextGame
+                  ? 'cursor-not-allowed text-gray-500'
+                  : 'transition-colors duration-200 hover:text-rose-400',
+              )}
+              onClick={onNextGame}
+              disabled={!hasNextGame}
+            >
+              <BsArrowRightCircle size={30} />
+            </button>
+          </div>
+          <div className="flex w-1/6 justify-end">
+            <div className="rounded-md bg-gray-700 px-4 py-2 text-white">
+              {game.endFlag === '3' ? '종료된 경기' : '예정 경기'}
+            </div>
+          </div>
+        </div>
+        <div className="flex justify-center text-base">
+          {game.gtime} {game.stadium}
+        </div>
+      </header>
+
+      <main className="grid grid-cols-3 gap-8">
+        <article className="flex flex-col items-center justify-center gap-2">
+          <img
+            src={game.visitLogo}
+            alt={game.visit}
+            className="h-32 w-32 object-contain"
+          />
+          <p className="text-lg font-semibold text-white">
+            {game.visit} (원정)
+          </p>
+          <p className="flex items-end gap-2 text-base text-gray-400">
+            <span className="text-lg text-gray-300">
+              {awayGameRecord.rank}위
+            </span>
+            {awayGameRecord.win}승 {awayGameRecord.lose}패{' '}
+            {awayGameRecord.drawn}무
+          </p>
+        </article>
+
+        <div className="flex flex-col items-center justify-center">
+          <div className="w-full">
+            <AnimatedStat
+              label="승률"
+              leftValue={awayGameRecord.wra}
+              rightValue={homeGameRecord.wra}
+            />
+            <AnimatedStat
+              label="타율"
+              leftValue={awayGameRecord.hra}
+              rightValue={homeGameRecord.hra}
+            />
+            <AnimatedStat
+              label="평균자책"
+              leftValue={awayGameRecord.era}
+              rightValue={homeGameRecord.era}
+            />
+            <AnimatedStat
+              label="상대전적"
+              leftValue={`${awayVsRecord.win}승`}
+              rightValue={`${homeVsRecord.win}승`}
+            />
+          </div>
+        </div>
+
+        <section className="flex flex-col items-center justify-center gap-2">
+          <img
+            src={game.homeLogo}
+            alt={game.home}
+            className="h-36 w-36 object-contain"
+          />
+          <span className="text-lg font-semibold text-white">
+            {game.home} (홈)
+          </span>
+          <p className="flex items-end gap-2 text-base text-gray-400">
+            <span className="text-lg text-gray-300">
+              {homeGameRecord.rank}위
+            </span>
+            {homeGameRecord.win}승 {homeGameRecord.lose}패{' '}
+            {homeGameRecord.drawn}무
+          </p>
+        </section>
+      </main>
+    </section>
+  );
+};
+
+export default WatchPointItem;

--- a/src/components/game/watchpoint/WatchPointSkeleton.tsx
+++ b/src/components/game/watchpoint/WatchPointSkeleton.tsx
@@ -1,0 +1,67 @@
+import { motion } from 'framer-motion';
+import { BsArrowLeftCircle, BsArrowRightCircle } from 'react-icons/bs';
+
+const WatchPointSkeleton = () => {
+  return (
+    <motion.section
+      className="relative mb-6 rounded-lg bg-kt-black-4 p-8"
+      animate={{
+        opacity: [1, 0.7, 1],
+        transition: {
+          duration: 1,
+          repeat: Infinity,
+          ease: 'easeInOut',
+        },
+      }}
+    >
+      <header className="mb-4 flex flex-col">
+        <div className="mb-2 flex items-center justify-between">
+          <div className="w-1/6"></div>
+          <div className="flex w-4/6 items-center justify-center gap-8">
+            <BsArrowLeftCircle size={30} className="text-gray-500" />
+            <div className="h-10 w-60 rounded bg-gray-600"></div>
+            <BsArrowRightCircle size={30} className="text-gray-500" />
+          </div>
+          <div className="flex w-1/6 justify-end">
+            <div className="h-10 w-28 rounded-md bg-gray-600"></div>
+          </div>
+        </div>
+        <div className="mt-2 flex justify-center">
+          <div className="h-6 w-24 rounded bg-gray-600"></div>
+        </div>
+      </header>
+
+      <main className="mt-10 grid grid-cols-3 gap-8">
+        <article className="flex flex-col items-center justify-center gap-2">
+          <div className="h-24 w-24 rounded-full bg-gray-600"></div>
+          <div className="mt-3 h-6 w-24 rounded bg-gray-600"></div>
+          <div className="mt-3 h-5 w-32 rounded bg-gray-600"></div>
+        </article>
+
+        <div className="flex flex-col items-center justify-center">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <article key={index} className="mb-4 w-full">
+              <div className="mb-1 flex justify-between">
+                <div className="h-6 w-14 rounded bg-gray-600"></div>
+                <div className="h-6 w-14 rounded bg-gray-600"></div>
+                <div className="h-6 w-14 rounded bg-gray-600"></div>
+              </div>
+              <div className="relative h-2 overflow-hidden rounded-full bg-gray-700">
+                <div className="absolute left-0 top-0 h-full bg-gray-700"></div>
+                <div className="absolute right-0 top-0 h-full bg-gray-700"></div>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <article className="flex flex-col items-center justify-center gap-2">
+          <div className="h-24 w-24 rounded-full bg-gray-600"></div>
+          <div className="mt-3 h-6 w-24 rounded bg-gray-600"></div>
+          <div className="mt-3 h-5 w-32 rounded bg-gray-600"></div>
+        </article>
+      </main>
+    </motion.section>
+  );
+};
+
+export default WatchPointSkeleton;

--- a/src/pages/Game/WatchPointPage.tsx
+++ b/src/pages/Game/WatchPointPage.tsx
@@ -1,8 +1,72 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import WatchPointItem from '@/components/game/watchpoint/WatchPointItem';
+import WatchPointSkeleton from '@/components/game/watchpoint/WatchPointSkeleton';
+import { useScheduleStore } from '@/stores/ScheduleStore';
+import { GetMonthSchedule } from '@/api/GetMonthSchedule';
+import { GetWatchPoint } from '@/api/GetWatchPoint';
+
 const WatchPointPage = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { year, month } = useScheduleStore();
+
+  const [gameDate, gmkey] = location.search.substring(1).split('&');
+
+  const { data: monthScheduleData } = GetMonthSchedule(year, month);
+
+  const lastFinishedGame = monthScheduleData?.data.list
+    .filter((game) => game.status === '2')
+    .pop();
+
+  const finalGameDate = parseInt(
+    String(gameDate || lastFinishedGame?.gameDate || '0'),
+  );
+  const finalGmkey = gmkey || lastFinishedGame?.gmkey || '';
+
+  const {
+    data: watchPointData,
+    isLoading,
+    error,
+  } = GetWatchPoint(finalGameDate, finalGmkey);
+  if (error) return <div>Error: {error}</div>;
+  if (!watchPointData?.data) return <WatchPointSkeleton />;
+
+  const handleNextGame = () => {
+    if (watchPointData?.data.schedule.next) {
+      const { gameDate: nextGameDate, gmkey: nextGmkey } =
+        watchPointData.data.schedule.next;
+      navigate(`/game/watchpoint?${nextGameDate}&${nextGmkey}`);
+    }
+  };
+
+  const handlePrevGame = () => {
+    if (watchPointData?.data.schedule.prev) {
+      const { gameDate: prevGameDate, gmkey: prevGmkey } =
+        watchPointData.data.schedule.prev;
+      navigate(`/game/watchpoint?${prevGameDate}&${prevGmkey}`);
+    }
+  };
+
   return (
-    <>
-      <h1>WatchPointPage</h1>
-    </>
+    <div className="flex flex-col gap-12">
+      {watchPointData.data &&
+        (isLoading ? (
+          <WatchPointSkeleton />
+        ) : (
+          <WatchPointItem
+            game={watchPointData.data.gameScore}
+            homeGameRecord={watchPointData.data.homeTeamRank}
+            awayGameRecord={watchPointData.data.visitTeamRank}
+            homeVsRecord={watchPointData.data.homeTeamWinLose}
+            awayVsRecord={watchPointData.data.visitTeamWinLose}
+            onNextGame={handleNextGame}
+            onPrevGame={handlePrevGame}
+            hasNextGame={!!watchPointData.data.schedule.next}
+            hasPrevGame={!!watchPointData.data.schedule.prev}
+          />
+        ))}
+    </div>
   );
 };
 

--- a/src/types/WatchPointType.ts
+++ b/src/types/WatchPointType.ts
@@ -1,0 +1,96 @@
+// WatchPoint의 gameScore 정보를 담는 타입
+export type WatchPointGameScoreType = {
+  bhomeName: string;
+  displayDate: string;
+  endFlag: string;
+  gameDate: number;
+  gmKey: string;
+  gtime: string;
+  hOutcome: string;
+  home: string;
+  homeKey: string;
+  homeLogo: string;
+  hpcode: string;
+  hpitcherName: string;
+  hscore: number;
+  stadium: string;
+  stadiumKey: string;
+  vOutcome: string;
+  visit: string;
+  visitKey: string;
+  visitLogo: string;
+  vpcode: string;
+  vpitcherName: string;
+  vscore: number;
+};
+
+// WatchPoint의 선수 라인업 정보를 담는 타입
+export type WatchPointPlayerLineupType = {
+  backnum: string;
+  birth: string;
+  career: string;
+  curBra: string;
+  curHra: string;
+  height: string;
+  hittype: string;
+  pcode: string;
+  money: string;
+  playerName: string;
+  playerPrvwImg: string;
+  pos: string;
+  posidName: string;
+  promise: string;
+  seq: number;
+  teamCode: string;
+  teamName: string;
+  weight: string;
+};
+
+// WatchPoint의 스케줄 정보를 담는 타입
+export type WatchPointScheduleType = {
+  broadcast: string;
+  cancelFlag: string;
+  crowdCn: number;
+  endFlag: string;
+  gameDate: number;
+  gday: number;
+  gmkey: string;
+  gmonth: number;
+  gtime: string;
+  gyear: string;
+  home: string;
+  homeKey: string;
+  hscore: number;
+  stadium: string;
+  stadiumKey: string;
+  visit: string;
+  visitKey: string;
+  vscore: number;
+};
+
+// 팀 순위 정보를 담는 타입
+export type WatchPointTeamRankType = {
+  ab: number; // 타수
+  bra: string;
+  continue1: string;
+  drawn: number; // 무승부
+  era: string; // 평균자책점
+  lastrank: number;
+  lose: number; // 패
+  rank: number;
+  teamName: string;
+  teamCode: string;
+  win: number; // 승
+  wra: string; // 승률
+  hra: string; // 타율
+};
+
+// 상대 전적 정보를 담는 타입
+export type WatchPointVsRecordType = {
+  drawn: number; // 무승부
+  lose: number; // 패
+  win: number; // 승
+  teamCode: string;
+  teamName: string;
+  vsTeamCode: string;
+};


### PR DESCRIPTION
## ⚾️ Related Issues

- close #33 

## 📝 Task Details

- 관전포인트 페이지로 들어갈 시 가장 최근에 경기가 종료된 경기가 렌더링됩니다.
- 관전포인트 상단에 팀 비교 부분을 퍼블리싱합니다.
- 관전포인트 api가 가져오는 중일 때 `skeleton`이 렌더링되도록 합니다.
- 화살표를 누르면 전날 및 다음 날의 정보가 나옵니다.

## 📂 References

- screenshots, GIFs, etc.

## 💕 Review Requirements

- Please fill out your review request.
