### PR TITLE
[FEAT] 찾아오기 페이지를 퍼블리싱합니다 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@commitlint/config-conventional": "^19.4.1",
         "@eslint/js": "^9.9.0",
         "@tanstack/eslint-plugin-query": "^5.53.0",
+        "@types/navermaps": "^3.7.8",
         "@types/node": "^22.5.2",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -2060,6 +2061,21 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
+      "dev": true
+    },
+    "node_modules/@types/navermaps": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/@types/navermaps/-/navermaps-3.7.8.tgz",
+      "integrity": "sha512-LzQffMWcUfhKzOuPpUONaXmMN6sAkNf92q1nycRplqorIl2oDjgdPftOw0LttTS0/k/YsotizawK+PtcRWbuog==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.5.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@commitlint/config-conventional": "^19.4.1",
     "@eslint/js": "^9.9.0",
     "@tanstack/eslint-plugin-query": "^5.53.0",
+    "@types/navermaps": "^3.7.8",
     "@types/node": "^22.5.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/src/components/direction/DirectionMap.tsx
+++ b/src/components/direction/DirectionMap.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from 'react';
+
+import markerIcon from '@/assets/logo/KTwiz_logo.svg';
+
+const DirectionMap = () => {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const lat = 37.2997553;
+  const lng = 127.0096685;
+  const zoom = 15;
+  const markerLat = 37.2997553;
+  const markerLng = 127.0096685;
+  const apiKey = import.meta.env.VITE_NAVER_MAP_API_KEY_ID;
+
+  useEffect(() => {
+    const initializeMap = () => {
+      if (!mapRef.current) return;
+
+      const mapOptions = {
+        center: new window.naver.maps.LatLng(lat, lng),
+        zoom: zoom,
+        scaleControl: false,
+        logoControl: false,
+        mapDataControl: false,
+        zoomControl: true,
+        minZoom: 10,
+        maxZoom: 20,
+      };
+
+      const map = new window.naver.maps.Map(mapRef.current, mapOptions);
+
+      const marker = new window.naver.maps.Marker({
+        position: new window.naver.maps.LatLng(markerLat, markerLng),
+        map: map,
+        icon: {
+          url: markerIcon,
+          scaledSize: new naver.maps.Size(80, 80),
+        },
+      });
+    };
+
+    const script = document.createElement('script');
+    script.src = `https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=${apiKey}`;
+    script.async = true;
+    script.onload = initializeMap;
+    document.head.appendChild(script);
+
+    return () => {
+      document.head.removeChild(script);
+    };
+  }, [lat, lng, zoom, markerLat, markerLng]);
+
+  return (
+    <div ref={mapRef} className="h-[70vh] w-full border-4 border-kt-red-3" />
+  );
+};
+
+export default DirectionMap;

--- a/src/components/direction/DirectionMap.tsx
+++ b/src/components/direction/DirectionMap.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { useEffect, useRef } from 'react';
 
 import markerIcon from '@/assets/logo/KTwiz_logo.svg';
@@ -28,6 +29,7 @@ const DirectionMap = () => {
 
       const map = new window.naver.maps.Map(mapRef.current, mapOptions);
 
+      // eslint-disable-next-line no-unused-vars
       const marker = new window.naver.maps.Marker({
         position: new window.naver.maps.LatLng(markerLat, markerLng),
         map: map,

--- a/src/components/direction/DirectionTable.tsx
+++ b/src/components/direction/DirectionTable.tsx
@@ -1,0 +1,27 @@
+import { DirectionData } from '@/data/DirectionData';
+
+const DirectionTable = () => {
+  return (
+    <section className="mt-12 flex w-full gap-3">
+      {DirectionData.map((item) => (
+        <div key={item.title} className="w-full">
+          <div
+            className="flex w-full items-center border-b-2 border-kt-gray-2 px-2 py-4"
+            key={item.title}
+          >
+            <h1 className="flex w-1/3 items-center gap-3 text-3xl font-bold text-kt-white">
+              <div>{item.icon}</div>
+              <div className="min-w-full">{item.title}</div>
+            </h1>
+          </div>
+          <ul className="mt-4 space-y-2">
+            {item.content.map((content, index) => (
+              <li key={index}>{content}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </section>
+  );
+};
+export default DirectionTable;

--- a/src/components/direction/DirectionTitle.tsx
+++ b/src/components/direction/DirectionTitle.tsx
@@ -1,0 +1,44 @@
+import { useRef } from 'react';
+
+import SectionHeading from '@/components/common/typography/SectionHeading';
+
+const DirectionTitle = () => {
+  const tooltipRef = useRef<HTMLSpanElement>(null); // 타입 명시
+
+  const handleMouseEnter = () => {
+    if (tooltipRef.current) {
+      tooltipRef.current.style.display = 'block'; // 마우스가 들어오면 말풍선 보이기
+    }
+  };
+
+  const handleMouseLeave = () => {
+    if (tooltipRef.current) {
+      tooltipRef.current.style.display = 'none'; // 마우스가 나가면 말풍선 숨기기
+    }
+  };
+
+  return (
+    <header className="flex items-center justify-between">
+      <SectionHeading title="수원 KT위즈파크 위치" />
+      <a
+        href="https://map.naver.com/p/entry/place/13491582?c=15.00,0,0,0,dh"
+        target="_blank"
+        className="relative mb-3 bg-kt-red-3 px-4 py-1 text-lg"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        찾아오기
+        <span
+          ref={tooltipRef} // 말풍선 요소에 ref 연결
+          className="absolute -left-8 top-14 z-[1000] hidden -translate-x-1/2 whitespace-nowrap rounded bg-kt-gray-2 px-2.5 py-1 text-kt-white"
+        >
+          찾아오기 버튼을 누르시면, <br />
+          출발지에서 야구장으로 가는 길을 <br />
+          쉽게 확인하실 수 있습니다.
+        </span>
+      </a>
+    </header>
+  );
+};
+
+export default DirectionTitle;

--- a/src/data/DirectionData.tsx
+++ b/src/data/DirectionData.tsx
@@ -1,0 +1,35 @@
+import { BsFillGeoAltFill } from 'react-icons/bs';
+import { FaBus } from 'react-icons/fa6';
+import { IoMdSubway } from 'react-icons/io';
+
+const iconColor = '#f53232';
+const iconSize = 40;
+export const DirectionData = [
+  {
+    icon: <BsFillGeoAltFill color={iconColor} size={iconSize} />,
+    title: '주소',
+    content: [
+      '경기도 수원시 장안구 경수대로 893(조원동) 수원',
+      '케이티 위즈 파크 (구 : 경기도 수원시 장안구 조원동 775)',
+    ],
+  },
+  {
+    icon: <FaBus color={iconColor} size={iconSize} />,
+    title: '버스',
+    content: [
+      '일반 25, 25-2, 27, 36, 55, 62-1, 99, 99-2, 300-1',
+      '일반 310, 777',
+      '직행 2007, 3000, 7770',
+      '좌석 300, 900',
+    ],
+  },
+  {
+    icon: <IoMdSubway color={iconColor} size={iconSize} />,
+    title: '지하철',
+    content: [
+      '37, 39번 버스이용 수성중 사거리 하차 후 도보 3분',
+      '55분 버스이용 종합운동장 하차 수원역하차 (택시로 20분)',
+      '1번, 5번, 8번 버스이용 수성중 사거리 하차 후 도보 3분',
+    ],
+  },
+];

--- a/src/pages/DirectionPage.tsx
+++ b/src/pages/DirectionPage.tsx
@@ -1,8 +1,20 @@
+import DetailPageLayout from '@/components/common/layout/DetailPageLayout';
+import DirectionMap from '@/components/direction/DirectionMap';
+import DirectionTable from '@/components/direction/DirectionTable';
+import DirectionTitle from '@/components/direction/DirectionTitle';
+import topImg from '@/assets/direction/direction_topImg.svg';
+
 const DirectionPage = () => {
   return (
-    <>
-      <h1>Direction Page</h1>
-    </>
+    <DetailPageLayout
+      topImg={topImg}
+      title="찾아오기"
+      subTitle="오시는 길을 상세하게 알려드립니다."
+    >
+      <DirectionTitle />
+      <DirectionMap />
+      <DirectionTable />
+    </DetailPageLayout>
   );
 };
 

--- a/src/types/DetailPageLayoutType.ts
+++ b/src/types/DetailPageLayoutType.ts
@@ -8,4 +8,4 @@ export type DetailPageLayoutProps = {
 };
 
 export type DetailPageLayoutWithTabsProps = DetailPageLayoutProps &
-  TabNavigationProps;
+  Partial<TabNavigationProps>;


### PR DESCRIPTION
## ⚾️ Related Issues

- close #52 

## 📝 Task Details

- 찾아오기 페이지를 퍼블리싱합니다
- 기존의 이미지로 표현된 위치를 지도 API로 구현합니다

## 📂 References
- 기존의 이미지로 표현된 위치를 지도 API로 구현합니다
![2024-09-26 05 49 27](https://github.com/user-attachments/assets/7ca1fe82-fa9b-4c1b-a5e3-c65ea6651cb4)

- 찾아오기 버튼에 호버하면 상세 설명이 나오고, 기존과 동일하게 네이버 지도로 이동합니다 

![2024-09-26 05 52 14](https://github.com/user-attachments/assets/a075243b-526c-4cf0-a3f4-b877f10d2ee6)

- 테이블 형태를 변경하여, 불필요한 공백을 줄였습니다

![image](https://github.com/user-attachments/assets/03c2fda8-85b8-4f2e-950f-66df865b678a)



## 💕 Review Requirements

- 탭이 없는 찾아오기 페이지를 위한 DetailPageLayout의 TabNavigationProps을 옵셔널 파라미터로 변경했습니다
- 옵셔널 파라미터로 변경 후 다른 페이지에서는 이상 없는 것을 확인 완료했습니다
