### PR TITLE
[FIX] DetailPageLayout, ScrollToTopButton에서 발생하는 버그를 수정합니다.

### DIFF
--- a/src/components/common/layout/DetailPageLayout.tsx
+++ b/src/components/common/layout/DetailPageLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 
 import { useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -24,6 +24,12 @@ const DetailPageLayout = ({
   const scrollableRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
 
+  const scrollToTop = useCallback(() => {
+    if (scrollableRef.current) {
+      scrollableRef.current.scrollTo(0, 0);
+    }
+  }, []);
+
   // 스크롤이 일정 위치 이상 내려가면 탭 네비게이션을 보여줌
   useEffect(() => {
     const handleScroll = () => {
@@ -38,6 +44,11 @@ const DetailPageLayout = ({
     currentRef?.addEventListener('scroll', handleScroll);
     return () => currentRef?.removeEventListener('scroll', handleScroll);
   }, []);
+
+  // 라우트 변경 시 스크롤 위치 리셋
+  useEffect(() => {
+    scrollToTop();
+  }, [location.pathname, scrollToTop]);
 
   const isHistoryPage = location.pathname === '/introduce/history';
 

--- a/src/components/common/layout/DetailPageLayout.tsx
+++ b/src/components/common/layout/DetailPageLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 
 import { useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -9,7 +9,6 @@ import ScrollToTopButton from '../ui/button/ScrollToTopButton';
 import { TabNavigation } from '@/components/common/ui/tab/TabNavigation';
 import { DropTabNavigation } from '@/components/common/ui/tab/DropTabNavigation';
 import { DetailPageLayoutWithTabsProps } from '@/types/DetailPageLayoutType';
-import { cn } from '@/utils/cn';
 
 const DetailPageLayout = ({
   topImg,
@@ -21,44 +20,35 @@ const DetailPageLayout = ({
   onTabChange,
 }: DetailPageLayoutWithTabsProps) => {
   const [showDropdownNav, setShowDropdownNav] = useState(false);
-  const scrollableRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
 
   const scrollToTop = useCallback(() => {
-    if (scrollableRef.current) {
-      scrollableRef.current.scrollTo(0, 0);
-    }
+    window.scrollTo(0, 0);
   }, []);
 
   // 스크롤이 일정 위치 이상 내려가면 탭 네비게이션을 보여줌
-  useEffect(() => {
-    const handleScroll = () => {
-      if (scrollableRef.current) {
-        const scrollPosition = scrollableRef.current.scrollTop;
-        const triggerPosition = window.innerHeight * 0.65;
-        setShowDropdownNav(scrollPosition > triggerPosition);
-      }
-    };
-
-    const currentRef = scrollableRef.current;
-    currentRef?.addEventListener('scroll', handleScroll);
-    return () => currentRef?.removeEventListener('scroll', handleScroll);
+  const updateDropdownNavVisibility = useCallback(() => {
+    const scrollPosition = window.scrollY;
+    const triggerPosition = window.innerHeight * 0.65;
+    setShowDropdownNav(scrollPosition > triggerPosition);
   }, []);
 
-  // 라우트 변경 시 스크롤 위치 리셋
+  useEffect(() => {
+    const handleScroll = () => {
+      updateDropdownNavVisibility();
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [updateDropdownNavVisibility]);
+
   useEffect(() => {
     scrollToTop();
+    setShowDropdownNav(false);
   }, [location.pathname, scrollToTop]);
 
-  const isHistoryPage = location.pathname === '/introduce/history';
-
   return (
-    <div
-      className={cn(
-        'relative min-h-screen',
-        !isHistoryPage && 'overflow-hidden',
-      )}
-    >
+    <div className="relative min-h-screen">
       {/* 상단 이미지 */}
       <div className="fixed left-0 top-0 h-full w-full">
         <img
@@ -69,13 +59,7 @@ const DetailPageLayout = ({
         <div className="absolute inset-0 bg-black opacity-75"></div>
       </div>
 
-      <div
-        className={cn(
-          'relative z-10',
-          !isHistoryPage && 'section-scrollble h-screen overflow-y-auto',
-        )}
-        ref={scrollableRef}
-      >
+      <div className="relative z-10">
         {/* 상단 타이틀 */}
         <div className="flex h-[65vh] flex-col items-center justify-center gap-6 pt-20">
           <motion.div
@@ -164,7 +148,11 @@ const DetailPageLayout = ({
             <DropTabNavigation
               tabs={tabs}
               activeTab={activeTab}
-              onTabChange={onTabChange}
+              onTabChange={(index) => {
+                onTabChange(index);
+                scrollToTop();
+                setShowDropdownNav(false);
+              }}
             />
           </motion.div>
         )}

--- a/src/components/common/ui/button/ScrollToTopButton.tsx
+++ b/src/components/common/ui/button/ScrollToTopButton.tsx
@@ -1,19 +1,16 @@
 import { useState, useEffect } from 'react';
 
-import { useLocation } from 'react-router-dom';
 import { motion, useAnimation, AnimatePresence } from 'framer-motion';
 import { MdOutlineVerticalAlignTop } from 'react-icons/md';
 
 const ScrollToTopButton = () => {
   const [showButton, setShowButton] = useState(false);
   const controls = useAnimation();
-  const location = useLocation();
 
   // 스크롤이 일정 위치 이상 내려가면 스크롤 버튼을 보여줌
   useEffect(() => {
     const handleScroll = () => {
-      const section = document.querySelector('.section-scrollble');
-      if (section && section.scrollTop > 200) {
+      if (window.scrollY > 200) {
         setShowButton(true);
       } else {
         setShowButton(false);
@@ -21,10 +18,9 @@ const ScrollToTopButton = () => {
     };
 
     // 스크롤 이벤트 등록
-    const section = document.querySelector('.section-scrollble');
-    section?.addEventListener('scroll', handleScroll);
+    window.addEventListener('scroll', handleScroll);
     return () => {
-      section?.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('scroll', handleScroll);
     };
   }, []);
 
@@ -44,11 +40,8 @@ const ScrollToTopButton = () => {
 
   // 스크롤 버튼 클릭 시 상단으로 이동
   const scrollToTop = () => {
-    const section = document.querySelector('.section-scrollble');
-    section?.scrollTo({ top: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
-
-  if (location.pathname === '/introduce/history') return null;
 
   return (
     <AnimatePresence>


### PR DESCRIPTION
## ⚾️ Related Issues

- close #65 

## 📝 Task Details

- 탭을 클릭했을 때 페이지가 맨 위로 스크롤되지 않는 문제를 수정합니다.
- `구단 연혁` 페이지로 이동 시, `DropTabNavigation`이 현재 위치가 맨 위에 있어도 사라지지 않는 문제를 해결합니다.
- `구단 연혁` 페이지 이외에 스크롤 부분이 `overflow-hidden`에 의해 네비게이션바에 가려지는 현상을 수정합니다.

## 📂 References

https://github.com/user-attachments/assets/ffdc745f-337f-4226-bf51-ad4c5c2bd4bf

1️⃣ `DetailPageLayout` 컴포넌트
- `useRef`와 `.section-scrollble` 클래스를 사용한 방식에서 `window` 객체를 직접 사용하는 방식으로 변경했습니다.
- 기존에는 급하게 하느라 `구단 연혁` 페이지에서만 조건부 처리를 해줬는데 조건부 스타일링을 제거했습니다.
- 탭 변경 시 페이지 상단으로 스크롤 및 `DropTabNavigation` 숨김 처리를 추가했습니다.

2️⃣ `ScrollToTopButton` 컴포넌트
- `.section-scrollble` 요소에서 `window` 객체로 변경했습니다.
- `section.scrollTop`에서 `window.scrollY`로 변경했습니다.
- `section?.scrollTo()`에서 `window.scrollTo()`로 변경했습니다.
- 조건부 렌더링을 제거했습니다. (구단 연혁 페이지 여부)

`window` 객체를 사용함으로써 간결한 코드를 확보했고, 페이지별로 다른 동작을 하던 코드를 통합했습니다. 또한 `구단 연혁` 페이지에서만 스크롤 화면이 다르게 렌더링 되었는데 이를 모든 페이지에서 동일한 스크롤 동작으로 변경하여 일관성을 높였습니다.

`useRef`를 사용하여 불필요한 DOM 조작이 발생했는데 이를 `window` 객체를 통해 줄였습니다.

## 💕 Review Requirements

- `ScrollToTop` 버튼을 프로젝트 발표 전날에 급하게 도입하여 오점이 많았습니다. 이를 간결한 코드와 일관성을 높였고 `구단 연혁` 페이지에서만 화면이 보이지 않았던 문제를 다시 해결했습니다.
