### PR TITLE
[REFACTOR] 라우터/페이지별 API 에러 핸들링을 구현합니다

### DIFF
--- a/src/api/HttpClient.ts
+++ b/src/api/HttpClient.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios';
+import axios, { AxiosError, AxiosInstance } from 'axios';
 
 const apiUrl = import.meta.env.VITE_API_URL;
 const BASE_URL = apiUrl;
@@ -15,7 +15,47 @@ HttpClient.interceptors.request.use(
     return config;
   },
   (error) => {
-    console.log(error);
+    if (error.message.includes('Network Error')) {
+      return Promise.reject(new Error('네트워크 오류가 발생했습니다'));
+    } else if (error.message.includes('timeout')) {
+      return Promise.reject(new Error('요청 시간이 초과되었습니다'));
+    } else {
+      return Promise.reject(
+        new Error(`요청 중 오류가 발생했습니다:${error.message}`),
+      );
+    }
+  },
+);
+
+HttpClient.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error: AxiosError) => {
+    if (error.response) {
+      switch (error.response.status) {
+        case 500:
+          return Promise.reject(new Error('서버에 오류가 발생했습니다'));
+        case 404:
+          return Promise.reject(new Error('요청한 페이지를 찾을 수 없습니다'));
+        case 400:
+          return Promise.reject(new Error('잘못된 요청입니다'));
+        case 401:
+          return Promise.reject(new Error('인증에 실패했습니다'));
+        case 403:
+          return Promise.reject(new Error('접근 권한이 없습니다'));
+        default:
+          return Promise.reject(
+            new Error(`오류가 발생했습니다: ${error.response.status}`),
+          );
+      }
+    } else if (error.request) {
+      return Promise.reject(new Error('서버로부터 응답이 없습니다'));
+    } else {
+      return Promise.reject(
+        new Error(`요청 중 오류가 발생했습니다: ${error.message}`),
+      );
+    }
   },
 );
 

--- a/src/components/error/ErrorAlert.tsx
+++ b/src/components/error/ErrorAlert.tsx
@@ -1,0 +1,27 @@
+import { cn } from '@/utils/cn';
+import { BiMessageAltError } from 'react-icons/bi';
+
+const ErrorAlert = ({
+  errorMsg,
+  type,
+  containerClassName,
+}: {
+  errorMsg: string;
+  type: 'page' | 'component';
+  containerClassName?: string;
+}) => {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center',
+        type === 'component' && 'rounded-md bg-[rgba(245,250,255,0.15)]',
+        containerClassName && containerClassName,
+      )}
+    >
+      <BiMessageAltError size={80} color="#717781" />
+      <p className="mt-3 font-bold text-kt-gray-2">{errorMsg}</p>
+    </div>
+  );
+};
+
+export default ErrorAlert;

--- a/src/components/game/ranking/GameRankingTable.tsx
+++ b/src/components/game/ranking/GameRankingTable.tsx
@@ -1,5 +1,7 @@
-import { DataTable } from '@/components/common/ui/table/DataTable';
 import { ColumnDef } from '@tanstack/react-table';
+
+import { DataTable } from '@/components/common/ui/table/DataTable';
+import ErrorAlert from '@/components/error/ErrorAlert';
 import GameRankingSectionFrame from '../GameRankingSectionFrame';
 
 interface WithTeamName {
@@ -11,6 +13,8 @@ interface GameRankingTableProps<T extends WithTeamName> {
   tableInfo: T[];
   columns: ColumnDef<T>[];
   isLoading: boolean;
+  isError?: boolean;
+  error?: string | null;
 }
 
 const GameRankingTable = <T extends WithTeamName>({
@@ -18,18 +22,28 @@ const GameRankingTable = <T extends WithTeamName>({
   tableInfo,
   columns,
   isLoading,
+  isError,
+  error,
 }: GameRankingTableProps<T>) => {
   const isHighlighted = (row: T) => row.teamName === 'KT';
 
   return (
     <GameRankingSectionFrame title={title} height="h-[50vh]" type="table">
-      <DataTable
-        data={tableInfo}
-        columns={columns}
-        bodyCellClassName="border-b border-gray-600 text-center"
-        highlightCondition={isHighlighted}
-        isLoading={isLoading}
-      />
+      {isError && error ? (
+        <ErrorAlert
+          errorMsg={error}
+          type="component"
+          containerClassName="py-20"
+        />
+      ) : (
+        <DataTable
+          data={tableInfo}
+          columns={columns}
+          bodyCellClassName="border-b border-gray-600 text-center"
+          highlightCondition={isHighlighted}
+          isLoading={isLoading}
+        />
+      )}
     </GameRankingSectionFrame>
   );
 };

--- a/src/components/game/ranking/player/PlayerRankingTable.tsx
+++ b/src/components/game/ranking/player/PlayerRankingTable.tsx
@@ -1,4 +1,8 @@
+import { ColumnDef } from '@tanstack/react-table';
+
 import { DataTable } from '@/components/common/ui/table/DataTable';
+import ErrorAlert from '@/components/error/ErrorAlert';
+import ErrorBoundary from '@/components/error/ErrorBoundary';
 import {
   TPlayerRankingColumn,
   TPlayerRankingTable,
@@ -9,7 +13,6 @@ import {
   TTotalBatterRankingTable,
   TTotalPitcherRankingTable,
 } from '@/types/PlayerRanking';
-import { ColumnDef } from '@tanstack/react-table';
 
 const PlayerRankingTable = ({
   activeTab,
@@ -26,57 +29,84 @@ const PlayerRankingTable = ({
   isError: boolean;
   error: string | null;
 }) => {
-  if (isError) {
-    return <p>Error: {error}</p>;
-  }
-  switch (activeTab) {
-    case '전체 투수 순위':
-      return (
-        <DataTable
-          data={tableData as TTotalPitcherRankingTable[]}
-          columns={tableColumns as ColumnDef<TTotalPitcherRankingTable>[]}
-          bodyCellClassName="border-b border-gray-600 text-center"
-          isLoading={isLoading}
-          enableSorting={true}
-          excludeSortingCount={3}
+  return (
+    <ErrorBoundary
+      fallback={
+        <ErrorAlert
+          errorMsg="페이지를 불러오는 중 오류가 발생했습니다."
+          type="component"
+          containerClassName="w-full py-20"
         />
-      );
-    case 'kt wiz 투수':
-      return (
-        <DataTable
-          data={tableData as TKTPitcherRankingTable[]}
-          columns={tableColumns as ColumnDef<TKTPitcherRankingTable>[]}
-          bodyCellClassName="border-b border-gray-600 text-center"
-          isLoading={isLoading}
-          enableSorting={true}
-          excludeSortingCount={2}
+      }
+    >
+      {isError && error ? (
+        <ErrorAlert
+          errorMsg={error}
+          type="component"
+          containerClassName="w-full py-20"
         />
-      );
-    case '전체 타자 순위':
-      return (
-        <DataTable
-          data={tableData as TTotalBatterRankingTable[]}
-          columns={tableColumns as ColumnDef<TTotalBatterRankingTable>[]}
-          bodyCellClassName="border-b border-gray-600 text-center"
-          isLoading={isLoading}
-          enableSorting={true}
-          excludeSortingCount={3}
-        />
-      );
-    case 'kt wiz 타자':
-      return (
-        <DataTable
-          data={tableData as TKTBatterRankingTable[]}
-          columns={tableColumns as ColumnDef<TKTBatterRankingTable>[]}
-          bodyCellClassName="border-b border-gray-600 text-center"
-          isLoading={isLoading}
-          enableSorting={true}
-          excludeSortingCount={2}
-        />
-      );
-    default:
-      return <p>Error</p>;
-  }
+      ) : (
+        <>
+          {(() => {
+            switch (activeTab) {
+              case '전체 투수 순위':
+                return (
+                  <DataTable
+                    data={tableData as TTotalPitcherRankingTable[]}
+                    columns={
+                      tableColumns as ColumnDef<TTotalPitcherRankingTable>[]
+                    }
+                    bodyCellClassName="border-b border-gray-600 text-center"
+                    isLoading={isLoading}
+                    enableSorting={true}
+                    excludeSortingCount={3}
+                  />
+                );
+              case 'kt wiz 투수':
+                return (
+                  <DataTable
+                    data={tableData as TKTPitcherRankingTable[]}
+                    columns={
+                      tableColumns as ColumnDef<TKTPitcherRankingTable>[]
+                    }
+                    bodyCellClassName="border-b border-gray-600 text-center"
+                    isLoading={isLoading}
+                    enableSorting={true}
+                    excludeSortingCount={2}
+                  />
+                );
+              case '전체 타자 순위':
+                return (
+                  <DataTable
+                    data={tableData as TTotalBatterRankingTable[]}
+                    columns={
+                      tableColumns as ColumnDef<TTotalBatterRankingTable>[]
+                    }
+                    bodyCellClassName="border-b border-gray-600 text-center"
+                    isLoading={isLoading}
+                    enableSorting={true}
+                    excludeSortingCount={3}
+                  />
+                );
+              case 'kt wiz 타자':
+                return (
+                  <DataTable
+                    data={tableData as TKTBatterRankingTable[]}
+                    columns={tableColumns as ColumnDef<TKTBatterRankingTable>[]}
+                    bodyCellClassName="border-b border-gray-600 text-center"
+                    isLoading={isLoading}
+                    enableSorting={true}
+                    excludeSortingCount={2}
+                  />
+                );
+              default:
+                return <p>Error</p>;
+            }
+          })()}
+        </>
+      )}
+    </ErrorBoundary>
+  );
 };
 
 export default PlayerRankingTable;

--- a/src/components/game/ranking/player/PlayerRankingTableSection.tsx
+++ b/src/components/game/ranking/player/PlayerRankingTableSection.tsx
@@ -9,7 +9,6 @@ import {
   TPlayerRankingColumn,
   TPlayerRankingTable,
 } from '@/types/PlayerRanking';
-import DataTableSkeleton from '@/components/common/ui/table/DataTableSkeleton';
 
 const PlayerRankingTableSection = ({
   rankingType,
@@ -79,10 +78,6 @@ const PlayerRankingTableSection = ({
     }
   };
 
-  if (isError) {
-    return <p>Error: {error}</p>;
-  }
-
   return (
     <section className="space-y-2">
       <div className="flex items-center justify-between">
@@ -99,9 +94,7 @@ const PlayerRankingTableSection = ({
       <p className="w-full text-end text-kt-gray-2">
         ※ 각 항목을 클릭하시면 오름차순/내림차순 정렬이 가능합니다.
       </p>
-      {!Array.isArray(data) ? (
-        <DataTableSkeleton />
-      ) : (
+      {Array.isArray(data) && (
         <PlayerRankingTable
           activeTab={activeTab}
           tableData={tableData}

--- a/src/components/game/ranking/player/TopFivePlayerList.tsx
+++ b/src/components/game/ranking/player/TopFivePlayerList.tsx
@@ -4,6 +4,8 @@ import { useAxios } from '@/hooks/useAxios';
 import { TPlayerRankingTopFive } from '@/types/PlayerRanking';
 import { TopFivePlayerListData } from '@/data/PlayerRankingData';
 import TopFivePlayerSkeleton from './TopFivePlayerSkeleton';
+import ErrorAlert from '@/components/error/ErrorAlert';
+import ErrorBoundary from '@/components/error/ErrorBoundary';
 
 const TopFivePlayerList = ({
   rankingType,
@@ -46,7 +48,14 @@ const TopFivePlayerList = ({
   });
 
   if (delayLoading) return <TopFivePlayerSkeleton />;
-  if (isError) return <div>{error}</div>;
+  if (isError && error)
+    return (
+      <ErrorAlert
+        errorMsg={error}
+        type="component"
+        containerClassName="w-1/4 py-10"
+      />
+    );
 
   const isTopFiveArray = (
     data: { data: { list: TPlayerRankingTopFive[] } } | TPlayerRankingTopFive[],
@@ -55,31 +64,41 @@ const TopFivePlayerList = ({
   };
 
   return (
-    <section className="ml-5 flex w-3/12 flex-col items-start justify-center text-kt-black-1">
-      <h1 className="mb-2 text-xl font-bold text-kt-white">
-        <strong className="text-kt-red-2">전체 {rankingTitle}</strong> TOP5
-      </h1>
-      <ul className="w-full text-kt-white">
-        {isTopFiveArray(data) &&
-          data.map((item) => (
-            <li
-              key={item.rank}
-              className="mt-2 flex w-full justify-between border-b-[1px] border-kt-gray-2"
-            >
-              <p>
-                {item.rank}. {item.playerName} ({item.teamName})
-              </p>
-              <p>
-                {item.era}
-                {item.hra}
-              </p>
-            </li>
-          ))}
-      </ul>
-      <div className="mt-3 w-full">
-        <p className="text-right text-kt-white">※ 2024 정규리그 시즌</p>
-      </div>
-    </section>
+    <ErrorBoundary
+      fallback={
+        <ErrorAlert
+          errorMsg="페이지를 불러오는 중 오류가 발생했습니다."
+          type="component"
+          containerClassName="w-1/4 py-10"
+        />
+      }
+    >
+      <section className="ml-5 flex w-1/4 flex-col items-start justify-center text-kt-black-1">
+        <h1 className="mb-2 text-xl font-bold text-kt-white">
+          <strong className="text-kt-red-2">전체 {rankingTitle}</strong> TOP5
+        </h1>
+        <ul className="w-full text-kt-white">
+          {isTopFiveArray(data) &&
+            data.map((item) => (
+              <li
+                key={item.rank}
+                className="mt-2 flex w-full justify-between border-b-[1px] border-kt-gray-2"
+              >
+                <p>
+                  {item.rank}. {item.playerName} ({item.teamName})
+                </p>
+                <p>
+                  {item.era}
+                  {item.hra}
+                </p>
+              </li>
+            ))}
+        </ul>
+        <div className="mt-3 w-full">
+          <p className="text-right text-kt-white">※ 2024 정규리그 시즌</p>
+        </div>
+      </section>
+    </ErrorBoundary>
   );
 };
 export default TopFivePlayerList;

--- a/src/components/game/ranking/player/TopThreePlayerFrame.tsx
+++ b/src/components/game/ranking/player/TopThreePlayerFrame.tsx
@@ -5,6 +5,7 @@ import { TopThreeListData } from '@/data/PlayerRankingData';
 import { TopThreePlayerRankingApi } from '@/api/TopThreePlayerRanking';
 import TopThreePlayerGroup from './TopThreePlayerGroup';
 import TopThreePlayerSkeleton from './TopThreePlayerSkeleton';
+import ErrorAlert from '@/components/error/ErrorAlert';
 
 const TopThreePlayerFrame = ({
   rankingType,
@@ -23,10 +24,18 @@ const TopThreePlayerFrame = ({
     );
   }, [rankingType]);
 
-  const { data: leftInfo, delayLoading: isLeftLoading } =
-    TopThreePlayerRankingApi(currentData[0]);
-  const { data: rightInfo, delayLoading: isRightLoading } =
-    TopThreePlayerRankingApi(currentData[1]);
+  const {
+    data: leftInfo,
+    delayLoading: isLeftLoading,
+    isError: isLeftError,
+    error: leftError,
+  } = TopThreePlayerRankingApi(currentData[0]);
+  const {
+    data: rightInfo,
+    delayLoading: isRightLoading,
+    isError: isRightError,
+    error: rightError,
+  } = TopThreePlayerRankingApi(currentData[1]);
 
   const isPlayerRankingTopThreeArray = (
     data:
@@ -36,31 +45,58 @@ const TopThreePlayerFrame = ({
     return Array.isArray(data);
   };
 
+  const renderError = (error: string) => (
+    <ErrorAlert
+      errorMsg={error}
+      type="component"
+      containerClassName="w-1/2 mx-3 py-10"
+    />
+  );
+
+  const renderPlayerGroup = (
+    title: string,
+    info: { data: { list: [] } } | TPlayerRankingTopThree[],
+    isLoading: boolean,
+    isError: boolean,
+    error: string | null,
+  ) => {
+    if (isLoading) {
+      return <TopThreePlayerSkeleton />;
+    }
+
+    if (isError && error) {
+      return renderError(error);
+    }
+
+    return (
+      isPlayerRankingTopThreeArray(info) && (
+        <TopThreePlayerGroup
+          title={title}
+          listInfo={info}
+          playerImg={info[0].playerPrvwImg}
+        />
+      )
+    );
+  };
+
   return (
     <div className="flex w-9/12">
-      {isLeftLoading ? (
-        <TopThreePlayerSkeleton />
-      ) : (
-        isPlayerRankingTopThreeArray(leftInfo) && (
-          <TopThreePlayerGroup
-            title={currentData[0].title}
-            listInfo={leftInfo}
-            playerImg={leftInfo[0].playerPrvwImg}
-          />
-        )
+      {renderPlayerGroup(
+        currentData[0].title,
+        leftInfo,
+        isLeftLoading,
+        isLeftError,
+        leftError,
       )}
-      {isRightLoading ? (
-        <TopThreePlayerSkeleton />
-      ) : (
-        isPlayerRankingTopThreeArray(rightInfo) && (
-          <TopThreePlayerGroup
-            title={currentData[1].title}
-            listInfo={rightInfo}
-            playerImg={rightInfo[0].playerPrvwImg}
-          />
-        )
+      {renderPlayerGroup(
+        currentData[1].title,
+        rightInfo,
+        isRightLoading,
+        isRightError,
+        rightError,
       )}
     </div>
   );
 };
+
 export default TopThreePlayerFrame;

--- a/src/components/game/ranking/team/TeamRankingPieGraphFrame.tsx
+++ b/src/components/game/ranking/team/TeamRankingPieGraphFrame.tsx
@@ -1,29 +1,59 @@
-import { TTeamRankingTeamVSTable } from '@/types/TeamRanking';
+import { useAxios } from '@/hooks/useAxios';
+import {
+  APITeamRankingTeamVSTable,
+  TTeamRankingTeamVSTable,
+} from '@/types/TeamRanking';
 import TeamRankingPieGraph from './TeamRankingPieGraph';
 import PieGraphSkeleton from '../PieGraphSkeleton';
+import ErrorAlert from '@/components/error/ErrorAlert';
+import ErrorBoundary from '@/components/error/ErrorBoundary';
 
-const TeamRankingPieGraphFrame = ({
-  graphInfo,
-  isLoading,
-}: {
-  graphInfo: TTeamRankingTeamVSTable[];
-  isLoading: boolean;
-}) => {
+const TeamRankingPieGraphFrame = () => {
+  const { data, delayLoading, isError, error } = useAxios<
+    APITeamRankingTeamVSTable,
+    TTeamRankingTeamVSTable[]
+  >({
+    url: '/game/rank/teamvs',
+    method: 'GET',
+    initialData: { data: { list: [] } },
+    shouldFetchOnMount: true,
+    processData: (data: APITeamRankingTeamVSTable) =>
+      data.data.list.filter((item) => item.teamCode === 'KT'),
+  });
+
+  if (delayLoading) {
+    return <PieGraphSkeleton />;
+  }
+  if (isError && error) {
+    return (
+      <ErrorAlert
+        errorMsg={error}
+        type="component"
+        containerClassName="w-full p-20"
+      />
+    );
+  }
+
   return (
-    <div className="mx-auto grid grid-cols-3 gap-4">
-      {graphInfo.map((item) =>
-        isLoading ? (
-          <PieGraphSkeleton
-            key={`${item.teamCode}-${item.vsTeamCode}-${item.teamName}-${item.teamCode}`}
-          />
-        ) : (
-          <TeamRankingPieGraph
-            key={`${item.teamCode}-${item.vsTeamCode}-${item.teamName}-${item.teamCode}`}
-            graphInfo={item}
-          />
-        ),
-      )}
-    </div>
+    <ErrorBoundary
+      fallback={
+        <ErrorAlert
+          errorMsg="페이지를 불러오는 중 오류가 발생했습니다."
+          type="component"
+          containerClassName="w-full p-20"
+        />
+      }
+    >
+      <div className="mx-auto grid grid-cols-3 gap-4">
+        {Array.isArray(data) &&
+          data.map((item) => (
+            <TeamRankingPieGraph
+              key={`${item.teamCode}-${item.vsTeamCode}-${item.teamName}-${item.teamCode}`}
+              graphInfo={item}
+            />
+          ))}
+      </div>
+    </ErrorBoundary>
   );
 };
 export default TeamRankingPieGraphFrame;

--- a/src/hooks/useAxios.ts
+++ b/src/hooks/useAxios.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 
-import axios, { AxiosError, ResponseType } from 'axios';
+import { ResponseType } from 'axios';
 
 import HttpClient from '@/api/HttpClient';
 
@@ -71,33 +71,8 @@ const useAxios = <T, R = T>({
       setIsError(false);
     } catch (error: unknown) {
       setIsError(true);
-      if (axios.isAxiosError(error)) {
-        const axiosError = error as AxiosError;
-        if (axiosError.response) {
-          switch (axiosError.response.status) {
-            case 500:
-              setError('서버에 오류가 발생했습니다');
-              break;
-            case 404:
-              setError('요청한 페이지를 찾을 수 없습니다');
-              break;
-            case 400:
-              setError('잘못된 요청입니다');
-              break;
-            case 401:
-              setError('인증에 실패했습니다');
-              break;
-            case 403:
-              setError('접근 권한이 없습니다');
-              break;
-            default:
-              setError(`오류가 발생했습니다: ${axiosError.response.status}`);
-          }
-        } else if (error.request) {
-          setError('서버로부터 응답이 없습니다');
-        } else {
-          setError(`요청 중 오류가 발생했습니다: ${error.message}`);
-        }
+      if (error instanceof Error) {
+        setError(error.message);
       }
     } finally {
       clearTimeout(timer);

--- a/src/pages/game/ranking/CrowdRankingPage.tsx
+++ b/src/pages/game/ranking/CrowdRankingPage.tsx
@@ -12,6 +12,8 @@ import CrowdRankingSelectYear from '@/components/game/ranking/crowd/CrowdRanking
 import GameRankingTable from '@/components/game/ranking/GameRankingTable';
 import { crowdRankingColumns } from '@/data/CrowdRankingTableData';
 import BarGraphSkeleton from '@/components/game/ranking/BarGraphSkeleton';
+import ErrorAlert from '@/components/error/ErrorAlert';
+import ErrorBoundary from '@/components/error/ErrorBoundary';
 
 const CrowdRankingPage = () => {
   const [selectedYear, setSelectedYear] = useState<number>(
@@ -76,39 +78,50 @@ const CrowdRankingPage = () => {
     setIsOpenSelectYears((isOpenSelectYears) => !isOpenSelectYears);
   };
 
-  if (isError) {
-    return <p>Error: {error}</p>;
+  if (isError && error) {
+    return <ErrorAlert errorMsg={error} type="page" />;
   }
 
   return (
-    <div className="flex flex-col gap-10">
-      <CrowdRankingSelectYear
-        selectedYear={selectedYear}
-        isOpenSelectYears={isOpenSelectYears}
-        years={years}
-        handleNextYear={handleNextYear}
-        handleOpenSelectYears={handleOpenSelectYear}
-        handlePreviousYear={handlePreviousYear}
-        handleYearClick={handleYearClick}
-      />
-      <GameRankingSectionFrame
-        title={`${selectedYear} 시즌 누적관중`}
-        height="h-[50vh]"
-        type="graph"
-      >
-        {delayLoading || !Array.isArray(CrowdRankingTotalData) ? (
-          <BarGraphSkeleton />
-        ) : (
-          <CrowdRankingGraph graphInfo={CrowdRankingTotalData} />
-        )}
-      </GameRankingSectionFrame>
-      <GameRankingTable<TCrowdRankingTable>
-        title={`${selectedYear} 시즌 관중`}
-        tableInfo={tableInfo}
-        columns={crowdRankingColumns}
-        isLoading={delayLoading}
-      />
-    </div>
+    <ErrorBoundary
+      fallback={
+        <ErrorAlert
+          errorMsg="페이지를 불러오는 중 오류가 발생했습니다."
+          type="page"
+        />
+      }
+    >
+      <div className="flex flex-col gap-10">
+        <CrowdRankingSelectYear
+          selectedYear={selectedYear}
+          isOpenSelectYears={isOpenSelectYears}
+          years={years}
+          handleNextYear={handleNextYear}
+          handleOpenSelectYears={handleOpenSelectYear}
+          handlePreviousYear={handlePreviousYear}
+          handleYearClick={handleYearClick}
+        />
+        <GameRankingSectionFrame
+          title={`${selectedYear} 시즌 누적관중`}
+          height="h-[50vh]"
+          type="graph"
+        >
+          {delayLoading ? (
+            <BarGraphSkeleton />
+          ) : (
+            Array.isArray(CrowdRankingTotalData) && (
+              <CrowdRankingGraph graphInfo={CrowdRankingTotalData} />
+            )
+          )}
+        </GameRankingSectionFrame>
+        <GameRankingTable<TCrowdRankingTable>
+          title={`${selectedYear} 시즌 관중`}
+          tableInfo={tableInfo}
+          columns={crowdRankingColumns}
+          isLoading={delayLoading}
+        />
+      </div>
+    </ErrorBoundary>
   );
 };
 export default CrowdRankingPage;

--- a/src/pages/game/ranking/TeamRankingPage.tsx
+++ b/src/pages/game/ranking/TeamRankingPage.tsx
@@ -4,12 +4,10 @@ import {
   APITeamRankingBatterTable,
   APITeamRankingGraph,
   APITeamRankingPitcherTable,
-  APITeamRankingTeamVSTable,
   APITeamRankingYearTable,
   TTeamRankingBatterTable,
   TTeamRankingGraph,
   TTeamRankingPitcherTable,
-  TTeamRankingTeamVSTable,
   TTeamRankingYearTable,
 } from '@/types/TeamRanking';
 import TeamRankingBarGraph from '@/components/game/ranking/team/TeamRankingBarGraph';
@@ -21,14 +19,16 @@ import { teamRankingPitcherColumns } from '@/data/TeamRankingPitcherTableData';
 import { teamRankingYearColumns } from '@/data/TeamRankingYearTableData';
 import { teamRankingBatterColumns } from '@/data/TeamRankingBatterTableData';
 import BarGraphSkeleton from '@/components/game/ranking/BarGraphSkeleton';
-import DataTableSkeleton from '@/components/common/ui/table/DataTableSkeleton';
-import PieGraphSkeleton from '@/components/game/ranking/PieGraphSkeleton';
+import ErrorAlert from '@/components/error/ErrorAlert';
+import ErrorBoundary from '@/components/error/ErrorBoundary';
 
 const TeamRankingPage = () => {
-  const { data: TeamRankingGraphData, delayLoading: isGraphLoading } = useAxios<
-    APITeamRankingGraph,
-    TTeamRankingGraph[]
-  >({
+  const {
+    data: TeamRankingGraphData,
+    delayLoading: isGraphLoading,
+    isError: isGraphError,
+    error: graphError,
+  } = useAxios<APITeamRankingGraph, TTeamRankingGraph[]>({
     url: '/game/rank/periodteamrank',
     method: 'GET',
     initialData: { data: { list: [] } },
@@ -36,18 +36,24 @@ const TeamRankingPage = () => {
     processData: (data: APITeamRankingGraph) => data.data.list,
   });
 
-  const { data: TeamRankingYearTableData, delayLoading: isYearTableLoading } =
-    useAxios<APITeamRankingYearTable, TTeamRankingYearTable[]>({
-      url: '/game/teamrankbyyear',
-      method: 'GET',
-      initialData: { data: { list: [] } },
-      shouldFetchOnMount: true,
-      processData: (data: APITeamRankingYearTable) => data.data.list,
-    });
+  const {
+    data: TeamRankingYearTableData,
+    delayLoading: isYearTableLoading,
+    isError: isYearTableError,
+    error: yearTableError,
+  } = useAxios<APITeamRankingYearTable, TTeamRankingYearTable[]>({
+    url: '/game/teamrankbyyear',
+    method: 'GET',
+    initialData: { data: { list: [] } },
+    shouldFetchOnMount: true,
+    processData: (data: APITeamRankingYearTable) => data.data.list,
+  });
 
   const {
     data: TeamRankingPitcherTableData,
     delayLoading: isPitcherTableLoading,
+    isError: isPitcherTableError,
+    error: pitcherTableError,
   } = useAxios<APITeamRankingPitcherTable, TTeamRankingPitcherTable[]>({
     url: '/game/rank/pitching',
     method: 'GET',
@@ -59,6 +65,8 @@ const TeamRankingPage = () => {
   const {
     data: TeamRankingBatterTableData,
     delayLoading: isBatterTableLoading,
+    isError: isBatterTableError,
+    error: batterTableError,
   } = useAxios<APITeamRankingBatterTable, TTeamRankingBatterTable[]>({
     url: '/game/rank/batting',
     method: 'GET',
@@ -67,73 +75,64 @@ const TeamRankingPage = () => {
     processData: (data: APITeamRankingBatterTable) => data.data.list,
   });
 
-  const {
-    data: TeamRankingTeamVSTableData,
-    delayLoading: isTeamVSTableLoading,
-  } = useAxios<APITeamRankingTeamVSTable, TTeamRankingTeamVSTable[]>({
-    url: '/game/rank/teamvs',
-    method: 'GET',
-    initialData: { data: { list: [] } },
-    shouldFetchOnMount: true,
-    processData: (data: APITeamRankingTeamVSTable) =>
-      data.data.list.filter((item) => item.teamCode === 'KT'),
-  });
-
   return (
-    <div className="flex flex-col gap-10">
-      <GameRankingSectionFrame
-        title="2024 시즌 팀 순위"
-        height="h-[50vh]"
-        type="graph"
-      >
-        {isGraphLoading || !Array.isArray(TeamRankingGraphData) ? (
-          <BarGraphSkeleton />
-        ) : (
-          <TeamRankingBarGraph graphInfo={TeamRankingGraphData} />
-        )}
-      </GameRankingSectionFrame>
-      {!Array.isArray(TeamRankingYearTableData) ? (
-        <DataTableSkeleton />
-      ) : (
+    <ErrorBoundary
+      fallback={
+        <ErrorAlert
+          type="page"
+          errorMsg="페이지를 불러오는 중 오류가 발생했습니다."
+        />
+      }
+    >
+      <div className="flex flex-col gap-10">
+        <GameRankingSectionFrame
+          title="2024 시즌 팀 순위"
+          height="h-[50vh]"
+          type="graph"
+        >
+          {isGraphLoading && <BarGraphSkeleton />}
+          {isGraphError && graphError ? (
+            <ErrorAlert
+              type="component"
+              errorMsg={graphError}
+              containerClassName="h-full"
+            />
+          ) : (
+            Array.isArray(TeamRankingGraphData) && (
+              <TeamRankingBarGraph graphInfo={TeamRankingGraphData} />
+            )
+          )}
+        </GameRankingSectionFrame>
         <GameRankingTable<TTeamRankingYearTable>
           title="2024 시즌 팀 기록"
-          tableInfo={TeamRankingYearTableData}
+          tableInfo={TeamRankingYearTableData as TTeamRankingYearTable[]}
           columns={teamRankingYearColumns}
           isLoading={isYearTableLoading}
+          isError={isYearTableError}
+          error={yearTableError}
         />
-      )}
-      {!Array.isArray(TeamRankingPitcherTableData) ? (
-        <DataTableSkeleton />
-      ) : (
         <GameRankingTable<TTeamRankingPitcherTable>
           title="2024 시즌 팀 투수 기록"
-          tableInfo={TeamRankingPitcherTableData}
+          tableInfo={TeamRankingPitcherTableData as TTeamRankingPitcherTable[]}
           columns={teamRankingPitcherColumns}
           isLoading={isPitcherTableLoading}
+          isError={isPitcherTableError}
+          error={pitcherTableError}
         />
-      )}
-      {!Array.isArray(TeamRankingBatterTableData) ? (
-        <DataTableSkeleton />
-      ) : (
         <GameRankingTable<TTeamRankingBatterTable>
           title="2024 시즌 팀 타자 기록"
-          tableInfo={TeamRankingBatterTableData}
+          tableInfo={TeamRankingBatterTableData as TTeamRankingBatterTable[]}
           columns={teamRankingBatterColumns}
           isLoading={isBatterTableLoading}
+          isError={isBatterTableError}
+          error={batterTableError}
         />
-      )}
-      <div>
-        <SectionHeading title="2024 시즌 팀 간 승패" />
-        {!Array.isArray(TeamRankingTeamVSTableData) ? (
-          <PieGraphSkeleton />
-        ) : (
-          <TeamRankingPieGraphFrame
-            graphInfo={TeamRankingTeamVSTableData}
-            isLoading={isTeamVSTableLoading}
-          />
-        )}
+        <div>
+          <SectionHeading title="2024 시즌 팀 간 승패" />
+          <TeamRankingPieGraphFrame />
+        </div>
       </div>
-    </div>
+    </ErrorBoundary>
   );
 };
 export default TeamRankingPage;

--- a/src/router/NotFoundPage.tsx
+++ b/src/router/NotFoundPage.tsx
@@ -1,0 +1,33 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Button } from '@/components/common/ui/button/button';
+
+const NotFoundPage = () => {
+  const navigate = useNavigate();
+  const goBack = () => {
+    navigate(-1);
+  };
+  return (
+    <div className="flex h-screen items-center justify-center bg-gray-300">
+      <div className="flex w-fit items-center justify-center gap-10 rounded-lg bg-kt-white px-28 py-16 drop-shadow-lg">
+        <div className="text-black">
+          <h1 className="mb-4 text-7xl font-bold">404 ERROR</h1>
+          <h2 className="mb-6 text-3xl font-semibold">
+            페이지를 찾을 수 없습니다
+          </h2>
+          <p>페이지가 존재하지 않거나, 사용할 수 없는 페이지입니다.</p>
+          <p>입력하신 주소가 정확한지 다시 한 번 확인해주세요 :)</p>
+          <div className="mt-6 space-x-2">
+            <Button variant="danger" onClick={goBack} className="rounded-md">
+              이전 페이지
+            </Button>
+            <Button onClick={() => navigate('/')} className="rounded-md">
+              KT WIZ 홈
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+export default NotFoundPage;

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -34,6 +34,7 @@ import GoogleOAuthHandler from '@/components/auth/common/GoogleAuthHandler';
 import KakaoOAuthHandler from '@/components/auth/common/KakaoAuthHandler';
 import CommunityPage from '@/pages/community/CommunityPage';
 import ChatPage from '@/pages/community/ChatPage';
+import NotFoundPage from './NotFoundPage';
 
 const Router = () => {
   const {
@@ -127,6 +128,7 @@ const Router = () => {
         { path: KAKAO_OAUTH, element: <KakaoOAuthHandler /> },
       ],
     },
+    { path: '*', element: <NotFoundPage /> },
   ]);
 
   return <RouterProvider router={router} />;


### PR DESCRIPTION
## ⚾️ Related Issues

- close #73 

## 📝 Task Details

- Router 에러
  - 페이지를 진입할 때 지정되지 않은 경로로 들어가면 NotFoundPage를 보여줍니다
  - NotFoundPage에는 "이전 페이지로 돌아가기"와 "홈 화면으로 가기" 버튼을 구현합니다
- 페이지별 API 에러
  - 페이지별 API에서 발생하는 에러를 핸들링합니다
  - 기존에 활용하지 않았던 axios의 intercepter에서 에러를 핸들링합니다
  - 공통 에러 컴포넌트를 퍼블리싱하여 최대한 많은 페이지에서 활용할 수 있도록 합니다

## 📂 References

### 404 에러 페이지
![image](https://github.com/user-attachments/assets/0ae877fb-7804-4dba-ad9e-7d7bd041f587)

### 페이지별 api 에러 컴포넌트 (src/components/error/ErrorAlert.tsx)
- 코드
```
import { cn } from '@/utils/cn';
import { BiMessageAltError } from 'react-icons/bi';

const ErrorAlert = ({
  errorMsg,
  type,
  containerClassName,
}: {
  errorMsg: string;
  type: 'page' | 'component';  // 페이지 전체에 사용할 건지, 일부 컴포넌트에 사용할 건지에 따라 스타일이 변경됨
  containerClassName?: string;  // 그외에도 커스텀할 수 있도록 className 지정 가능
}) => {
  return (
    <div
      className={cn(
        'flex flex-col items-center justify-center',
        type === 'component' && 'rounded-md bg-[rgba(245,250,255,0.15)]',
        containerClassName && containerClassName,
      )}
    >
      <BiMessageAltError size={80} color="#717781" />
      <p className="mt-3 font-bold text-kt-gray-2">{errorMsg}</p>
    </div>
  );
};

export default ErrorAlert;
```
- 페이지 전체에 사용할 경우 예시 (배경색이 없음)
![image](https://github.com/user-attachments/assets/5b5c4178-0e1f-4dff-b994-e37393b97614)

- 일부 컴포넌트에 사용할 경우 예시 (다른 내용과 구분될 수 있도록 배경색 있음)
![image](https://github.com/user-attachments/assets/561d4423-d84e-486b-b85d-ce77efa67a5a)

## 💕 Review Requirements

### 기존 useAxios에서 에러 분기 처리되었던 코드를 axios Interceptor에서 처리될 수 있도록 변경함
- src/api/HttpClient.ts
```
import axios, { AxiosError, AxiosInstance } from 'axios';

const apiUrl = import.meta.env.VITE_API_URL;
const BASE_URL = apiUrl;
	@@ -15,7 +15,47 @@ HttpClient.interceptors.request.use(
    return config;
  },
  (error) => { // 요청 중에 오류가 발생한 경우
    if (error.message.includes('Network Error')) {
      return Promise.reject(new Error('네트워크 오류가 발생했습니다'));
    } else if (error.message.includes('timeout')) {
      return Promise.reject(new Error('요청 시간이 초과되었습니다'));
    } else {
      return Promise.reject(
        new Error(`요청 중 오류가 발생했습니다:${error.message}`),
      );
    }
  },
);

HttpClient.interceptors.response.use(
  (response) => {
    return response;
  },
  (error: AxiosError) => {
    if (error.response) { // 서버에서 응답을 받는 중에 오류가 발생한 경우
      switch (error.response.status) {
        case 500:
          return Promise.reject(new Error('서버에 오류가 발생했습니다'));
        case 404:
          return Promise.reject(new Error('요청한 페이지를 찾을 수 없습니다'));
        case 400:
          return Promise.reject(new Error('잘못된 요청입니다'));
        case 401:
          return Promise.reject(new Error('인증에 실패했습니다'));
        case 403:
          return Promise.reject(new Error('접근 권한이 없습니다'));
        default:
          return Promise.reject(
            new Error(`오류가 발생했습니다: ${error.response.status}`),
          );
      }
    } else if (error.request) {
      return Promise.reject(new Error('서버로부터 응답이 없습니다'));
    } else {
      return Promise.reject(
        new Error(`요청 중 오류가 발생했습니다: ${error.message}`),
      );
    }
  },
);
```
- useAxios의 catch 문 내 에러 분기처리 코드 삭제함

#### 추후 안건
- 이후에 CRUD가 구현된다면 폼을 제출할 때 발생하는 오류는 토스트 메시지로 출력하도록 구현하는 게 좋을 것 같습니다