### PR TITLE
[FEAT] 회원가입 및 로그인 과정을 백엔드와 연동합니다.

### DIFF
--- a/src/api/HttpClient.ts
+++ b/src/api/HttpClient.ts
@@ -1,62 +1,77 @@
-import axios, { AxiosError, AxiosInstance } from 'axios';
+import axios, { AxiosError, AxiosInstance, CreateAxiosDefaults } from 'axios';
 
-const apiUrl = import.meta.env.VITE_API_URL;
-const BASE_URL = apiUrl;
+type ServerType = 'kt' | 'backend';
 
-const HttpClient: AxiosInstance = axios.create({
-  baseURL: BASE_URL,
-});
+const API_URLS = {
+  kt: import.meta.env.VITE_API_URL,
+  backend: import.meta.env.VITE_API_SERVER_URL,
+};
 
-HttpClient.interceptors.request.use(
-  (config) => {
-    if (config.headers) {
-      // header를 설정하는 코드를 작성
-    }
-    return config;
-  },
-  (error) => {
-    if (error.message.includes('Network Error')) {
-      return Promise.reject(new Error('네트워크 오류가 발생했습니다'));
-    } else if (error.message.includes('timeout')) {
-      return Promise.reject(new Error('요청 시간이 초과되었습니다'));
-    } else {
-      return Promise.reject(
-        new Error(`요청 중 오류가 발생했습니다:${error.message}`),
-      );
-    }
-  },
-);
+const createHttpClient = (serverType: ServerType): AxiosInstance => {
+  const config: CreateAxiosDefaults = {
+    baseURL: API_URLS[serverType],
+  };
 
-HttpClient.interceptors.response.use(
-  (response) => {
-    return response;
-  },
-  (error: AxiosError) => {
-    if (error.response) {
-      switch (error.response.status) {
-        case 500:
-          return Promise.reject(new Error('서버에 오류가 발생했습니다'));
-        case 404:
-          return Promise.reject(new Error('요청한 페이지를 찾을 수 없습니다'));
-        case 400:
-          return Promise.reject(new Error('잘못된 요청입니다'));
-        case 401:
-          return Promise.reject(new Error('인증에 실패했습니다'));
-        case 403:
-          return Promise.reject(new Error('접근 권한이 없습니다'));
-        default:
-          return Promise.reject(
-            new Error(`오류가 발생했습니다: ${error.response.status}`),
-          );
+  const instance = axios.create(config);
+
+  instance.interceptors.request.use(
+    (config) => {
+      if (config.headers) {
+        // header를 설정하는 코드를 작성
       }
-    } else if (error.request) {
-      return Promise.reject(new Error('서버로부터 응답이 없습니다'));
-    } else {
-      return Promise.reject(
-        new Error(`요청 중 오류가 발생했습니다: ${error.message}`),
-      );
-    }
-  },
-);
+      return config;
+    },
+    (error) => {
+      if (error.message.includes('Network Error')) {
+        return Promise.reject(new Error('네트워크 오류가 발생했습니다'));
+      } else if (error.message.includes('timeout')) {
+        return Promise.reject(new Error('요청 시간이 초과되었습니다'));
+      } else {
+        return Promise.reject(
+          new Error(`요청 중 오류가 발생했습니다:${error.message}`),
+        );
+      }
+    },
+  );
 
-export default HttpClient;
+  instance.interceptors.response.use(
+    (response) => {
+      return response;
+    },
+    (error: AxiosError) => {
+      if (error.response) {
+        switch (error.response.status) {
+          case 500:
+            return Promise.reject(new Error('서버에 오류가 발생했습니다'));
+          case 404:
+            return Promise.reject(
+              new Error('요청한 페이지를 찾을 수 없습니다'),
+            );
+          case 400:
+            return Promise.reject(new Error('잘못된 요청입니다'));
+          case 401:
+            return Promise.reject(new Error('인증에 실패했습니다'));
+          case 403:
+            return Promise.reject(new Error('접근 권한이 없습니다'));
+          default:
+            return Promise.reject(
+              new Error(`오류가 발생했습니다: ${error.response.status}`),
+            );
+        }
+      } else if (error.request) {
+        return Promise.reject(new Error('서버로부터 응답이 없습니다'));
+      } else {
+        return Promise.reject(
+          new Error(`요청 중 오류가 발생했습니다: ${error.message}`),
+        );
+      }
+    },
+  );
+
+  return instance;
+};
+
+export const KtHttpClient = createHttpClient('kt');
+export const BackendHttpClient = createHttpClient('backend');
+
+export default KtHttpClient;

--- a/src/components/auth/schemas/LoginFormSchema.ts
+++ b/src/components/auth/schemas/LoginFormSchema.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 
 const defaultValues = {
-  id: '',
+  username: '',
   password: '',
 };
 
 const LoginFormSchema = z.object({
-  id: z.string().min(3, { message: '아이디는 3자 이상 입력해주세요.' }),
+  username: z.string().min(3, { message: '아이디는 3자 이상 입력해주세요.' }),
   password: z.string().min(8, { message: '비밀번호는 8자 이상 입력해주세요.' }),
 });
 

--- a/src/components/auth/schemas/SignupFormSchema.ts
+++ b/src/components/auth/schemas/SignupFormSchema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 const defaultValues = {
   email: '',
   nickname: '',
-  id: '',
+  username: '',
   password: '',
   passwordConfirm: '',
 };
@@ -18,7 +18,7 @@ const SignupFormSchema = z
       .string()
       .min(3, { message: '닉네임은 3자 이상 입력해주세요.' })
       .max(10, { message: '닉네임은 10자 이하로 입력해주세요.' }),
-    id: z
+    username: z
       .string()
       .min(3, { message: '아이디는 3자 이상 입력해주세요.' })
       .max(10, { message: '아이디는 10자 이하로 입력해주세요.' })

--- a/src/components/header/NavigationBarAuth.tsx
+++ b/src/components/header/NavigationBarAuth.tsx
@@ -1,23 +1,56 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
 
+import { useAuthStore } from '@/stores/AuthStore';
 import { cn } from '@/utils/cn';
 
 const NavigationBarAuth = () => {
+  const navigate = useNavigate();
+  const { accessToken, clearAccessToken } = useAuthStore();
+
+  const handleLogout = () => {
+    clearAccessToken();
+    navigate('/');
+  };
+
   return (
     <div className="absolute right-6 top-6">
-      <NavLink
-        to="/login"
-        className={({ isActive }) =>
-          cn(
-            'rounded-md border border-white px-2 py-1.5 text-lg font-extrabold transition-colors duration-300',
-            isActive
-              ? 'bg-white text-red-800 hover:border hover:border-white hover:bg-transparent hover:text-white'
-              : 'hover:border hover:border-white hover:bg-white hover:text-red-800',
-          )
-        }
-      >
-        LOGIN
-      </NavLink>
+      {accessToken ? (
+        <>
+          <NavLink
+            to="/profile"
+            className={({ isActive }) =>
+              cn(
+                'mr-2 rounded-md border border-white px-2 py-1.5 text-lg font-extrabold transition-colors duration-300',
+                isActive
+                  ? 'bg-white text-red-800 hover:border hover:border-white hover:bg-transparent hover:text-white'
+                  : 'hover:border hover:border-white hover:bg-white hover:text-red-800',
+              )
+            }
+          >
+            내 정보
+          </NavLink>
+          <button
+            onClick={handleLogout}
+            className="rounded-md border border-white px-2 py-1.5 text-lg font-extrabold transition-colors duration-300 hover:border hover:border-white hover:bg-white hover:text-red-800"
+          >
+            LOGOUT
+          </button>
+        </>
+      ) : (
+        <NavLink
+          to="/login"
+          className={({ isActive }) =>
+            cn(
+              'rounded-md border border-white px-2 py-1.5 text-lg font-extrabold transition-colors duration-300',
+              isActive
+                ? 'bg-white text-red-800 hover:border hover:border-white hover:bg-transparent hover:text-white'
+                : 'hover:border hover:border-white hover:bg-white hover:text-red-800',
+            )
+          }
+        >
+          LOGIN
+        </NavLink>
+      )}
     </div>
   );
 };

--- a/src/stores/AuthStore.ts
+++ b/src/stores/AuthStore.ts
@@ -1,18 +1,72 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+// import axios from 'axios';
+
+type Provider = 'google' | 'kakao' | 'general';
 
 type AuthStoreType = {
   accessToken: string | null;
-  provider: 'google' | 'kakao' | null;
-  setAccessToken: (token: string, provider: 'google' | 'kakao') => void;
+  provider: Provider | null;
+  setAccessToken: (token: string, provider: Provider) => void;
   clearAccessToken: () => void;
+  // refreshToken: () => Promise<string | null>;
 };
 
-const useAuthStore = create<AuthStoreType>((set) => ({
-  accessToken: null,
-  provider: null,
-  setAccessToken: (token: string, provider: 'google' | 'kakao') =>
-    set({ accessToken: token, provider }),
-  clearAccessToken: () => set({ accessToken: null, provider: null }),
-}));
+const useAuthStore = create<AuthStoreType>()(
+  persist(
+    (set) => ({
+      accessToken: null,
+      provider: null,
+      setAccessToken: (token: string, provider: Provider) =>
+        set({ accessToken: token, provider }),
+      clearAccessToken: () => set({ accessToken: null, provider: null }),
+    }),
+    {
+      name: 'auth-storage',
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);
 
 export { useAuthStore };
+
+// ((set, get) => ({
+// accessToken: null,
+// provider: null,
+// setAccessToken: (token: string, provider: Provider) =>
+//   set({ accessToken: token, provider }),
+// clearAccessToken: () => set({ accessToken: null, provider: null }),
+// refreshToken: async () => {
+//   try {
+//     const response = await axios.post<{ accessToken: string }>(
+//       '/api/refresh-token',
+//       {},
+//       {
+//         withCredentials: true, // 리프레시 토큰이 HttpOnly 쿠키에 있다고 가정
+//       },
+//     );
+//     const newToken = response.data.accessToken;
+//     set({ accessToken: newToken });
+//     return newToken;
+//   } catch (error) {
+//     console.error('토큰 갱신 실패:', error);
+//     get().clearAccessToken();
+//     return null;
+//   }
+// },
+// }));
+
+// axios 인터셉터를 설정하여 401 에러가 발생하면 리프레시 토큰을 사용하여 토큰을 갱신하도록 함
+// axios.interceptors.response.use(
+//   (response) => response,
+//   async (error) => {
+//     if (error.response && error.response.status === 401) {
+//       const newToken = await useAuthStore.getState().refreshToken();
+//       if (newToken) {
+//         error.config.headers['Authorization'] = `Bearer ${newToken}`;
+//         return axios.request(error.config);
+//       }
+//     }
+//     return Promise.reject(error);
+//   },
+// );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,21 @@ import react from '@vitejs/plugin-react-swc';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { resolve } from 'path';
 
+const url = process.env.VITE_API_SERVER_URL;
+
 // https://vitejs.dev/config/
 export default defineConfig({
   resolve: {
     alias: { find: '@', replacement: resolve(__dirname, 'src') },
   },
   plugins: [react(), tsconfigPaths()],
+  server: {
+    proxy: {
+      '/yclinghomerun': {
+        target: url,
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/yclinghomerun/, ''),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## ⚾️ Related Issues

- close #77 

## 📝 Task Details

- 엑세스토큰을 받아 로그인을 진행합니다.
- `useAxios`훅과 `HttpClient` 파일을 수정합니다. (kt에서 받아오는 api와 백엔드에서 받아오는 api를 구분하기 위함)
- 엑세스토큰이 저장소에서 확인되면 네비게이션바에 `내 정보`와 `logout`버튼이 추가됩니다. (스타일은 깨지는 상태입니다.)
- `logout` 버튼을 클릭 시 메모리에서 토큰을 사라지게 하여 로그아웃 처리가 됩니다.
- `useOAuthHandler`훅에서는 소셜로그인 엑세스토큰이 있지만 유효한지 검사를 하며, 유효하지 않을 경우 리프레시 토큰을 요청하여 토큰을 갱신하도록 로직을 추가해놨습니다. 

## 📂 References

https://github.com/user-attachments/assets/e2f15ece-81e9-41da-b50f-f178a5cf95a9

## 💕 Review Requirements

- 프로젝트 전에 미리 작성해둔 로그인/회원가입 폼이 제대로 작동해서 다행이네요! 코드 관점에서 수정할 점 있으면 말씀해주세요! 
- 제가 생각했던 엑세스 토큰 저장은 메모리에 저장하고 타 페이지로 이동 시 리프레시 토큰을 요청해서 수행하는 방법으로 진행하려 했는데 일단은 `zustand`의 함수를 사용해서 스토리지에 저장되도록 했습니다!
- OAuth 로직은 미리 작성해뒀던 로직이라 일단 리프레시 토큰 로직으로 넣어놨습니다.
- swagger를 확인해보니까 OAuth도 있던데 설마 OAuth도 구현 됐나요..?
